### PR TITLE
Add Mongo Express and direct access to MongoDB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@ COMPOSE_PATH_SEPARATOR=:
 # List of Compose files to concatenate
 # Add here when adding new services
 # See: https://docs.docker.com/compose/how-tos/environment-variables/envvars/#compose_file
-COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml:user-service/docker-compose.yml
+COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml:user-service/docker-compose.yml:user-service/docker-compose.dev.yml
 
 #> Application Settings
 # Application port used by the main proxy for local development
@@ -34,6 +34,7 @@ SRV_USER_MONGO_ROOT_PASSWORD_FILE= # alternative to use a file for docker-secret
 SRV_USER_MONGO_DATABASE=user-service
 SRV_USER_MONGO_USERNAME=mongo
 SRV_USER_MONGO_PASSWORD=super-cool-password123
+SRV_USER_MONGO_DEV_PORT=3101 # access to db directly for local development
 
 # SMTP
 SRV_USER_SMTP_HOST=mailhog

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For education purposes only.
 - Gateway: Traefik for routing and edge concerns.
 - Tooling: Docker & Docker Compose for local development.
 
-## How to run
+## Setup
 
 Prerequisites: Go 1.22+, Node.js v24.x, Docker, and Docker Compose.
 
@@ -41,6 +41,16 @@ Setup:
 3. Start everything: `docker compose up --build`
 
 To rebuild/restart one service (example: user-service): `docker compose up -d --build user-service`
+
+## Development
+
+To run in development mode, follow the [Setup](#setup) steps.
+
+There are additional services available for local development:
+
+- `localhost:8000` - Traefik dashboard
+- `localhost:3101` - User Service MongoDB direct connection
+- `localhost:3000/dev/user-service` - [Mongo Express](https://github.com/mongo-express/mongo-express) to User Service
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ For education purposes only.
 > - `frontend` is served at the root (`/`).
 > - other microservices are served at `/api/<service-name>/...` (e.g. `/api/users/...`); Traefik strips the `/api/<service-name>` prefix before forwarding the request.
 
+> [!NOTE] Read `README.md` located in each service for more details.
+> Such as the port acccssible and the environment variables used for development.
+
 ## Tech stack
 
 - Backend: Go >= 1.22, REST/JSON APIs, containerized per service.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To run in development mode, follow the [Setup](#setup) steps.
 
 There are additional services available for local development:
 
-- `localhost:8000` - Traefik dashboard
+- `localhost:8080` - Traefik dashboard
 - `localhost:3101` - User Service MongoDB direct connection
 - `localhost:3000/dev/user-service` - [Mongo Express](https://github.com/mongo-express/mongo-express) to User Service
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To run in development mode, follow the [Setup](#setup) steps.
 There are additional services available for local development:
 
 - `localhost:8080` - Traefik dashboard
-- `localhost:3101` - User Service MongoDB direct connection
+- `localhost:3101` - User Service's MongoDB direct connection
 - `localhost:3000/dev/user-service` - [Mongo Express](https://github.com/mongo-express/mongo-express) to User Service
 
 ## Contributing

--- a/user-service/README.md
+++ b/user-service/README.md
@@ -1,36 +1,52 @@
 # User service
 
-- The purpose of this service is to handle role-based user authentication, 
-user registration, log out with session termination, forcing good practices
-with occasional password resets, account recovery via magic link as well as
-access/refresh token issuing.
+A microservice for user authentication, registration, and management.
 
-## The idea behind the data model and database choice
+## Tech stack
 
-- We took time to do our research and have concluded on why is document-oriented 
-database the best choice for this service. User entity requires storing nested 
-data such as profile info, settings, roles physically close together in a single
-JSON/BSON document. This approach minimizes latency and maximizes reading performance, 
-which is a core benefit provided by document-oriented DB's. By applying a unique
-secondary index on the email/username field, we ensure that the required user
-document can be located and fetched with high performance, making the login process
-efficient and reliable.
+- Go 1.25.5
+- MongoDB
 
-## User entity structure
+## Development
+
+Additional services are available for local development:
+
+- `localhost:3000/dev/user-service` - serves [mongo-express](https://github.com/mongo-express/mongo-express)
+- `localhost:3101` - direct connection to MongoDB
+
+## Structure
+
+- The purpose of this service is to handle role-based user authentication,
+  user registration, log out with session termination, forcing good practices
+  with occasional password resets, account recovery via magic link as well as
+  access/refresh token issuing.
+
+### The idea behind the data model and database choice
+
+- We took time to do our research and have concluded on why is document-oriented
+  database the best choice for this service. User entity requires storing nested
+  data such as profile info, settings, roles physically close together in a single
+  JSON/BSON document. This approach minimizes latency and maximizes reading performance,
+  which is a core benefit provided by document-oriented DB's. By applying a unique
+  secondary index on the email/username field, we ensure that the required user
+  document can be located and fetched with high performance, making the login process
+  efficient and reliable.
+
+### User entity structure
 
 ```json
 {
-  "id": "UUID",
-  "username": "string (unique)",
-  "firstName": "string",
-  "lastName": "string",
-  "email": "string (unique)",
-  "password": "string",
-  "role": "MEMBER | ADMIN",
-  "passwordLastChanged": "timestamp",
-  "passwordExpiresAt": "timestamp",
-  "accountStatus": "ACTIVE | INACTIVE",
-  "createdAt": "timestamp",
-  "updatedAt": "timestamp"
+	"id": "UUID",
+	"username": "string (unique)",
+	"firstName": "string",
+	"lastName": "string",
+	"email": "string (unique)",
+	"password": "string",
+	"role": "MEMBER | ADMIN",
+	"passwordLastChanged": "timestamp",
+	"passwordExpiresAt": "timestamp",
+	"accountStatus": "ACTIVE | INACTIVE",
+	"createdAt": "timestamp",
+	"updatedAt": "timestamp"
 }
 ```

--- a/user-service/docker-compose.dev.yml
+++ b/user-service/docker-compose.dev.yml
@@ -12,8 +12,7 @@ services:
       - "traefik.http.middlewares.user-mongo-express-strip-prefix.stripprefix.forceslash=false"
       - "traefik.http.services.user-mongo-express.loadbalancer.server.port=8081"
     environment:
-      ME_CONFIG_BASICAUTH_USERNAME: admin
-      ME_CONFIG_BASICAUTH_PASSWORD: admin
+      ME_CONFIG_BASICAUTH: "false"
       ME_CONFIG_SITE_BASEURL: /dev/user-service
       ME_CONFIG_MONGODB_URL: mongodb://${SRV_USER_MONGO_ROOT_USERNAME}:${SRV_USER_MONGO_ROOT_PASSWORD}@user-mongodb:27017/?authSource=admin
     depends_on:

--- a/user-service/docker-compose.dev.yml
+++ b/user-service/docker-compose.dev.yml
@@ -1,0 +1,28 @@
+services:
+  user-mongodb:
+    ports:
+      - ${SRV_USER_MONGO_DEV_PORT}:27017
+
+  user-mongo-express:
+    image: mongo-express
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=api-gateway"
+      - "traefik.http.routers.user-mongo-express.rule=PathPrefix(`/dev/user-service`)"
+      - "traefik.http.middlewares.user-mongo-express-strip-prefix.stripprefix.forceslash=false"
+      - "traefik.http.services.user-mongo-express.loadbalancer.server.port=8081"
+    environment:
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD: admin
+      ME_CONFIG_SITE_BASEURL: /dev/user-service
+      ME_CONFIG_MONGODB_URL: mongodb://${SRV_USER_MONGO_ROOT_USERNAME}:${SRV_USER_MONGO_ROOT_PASSWORD}@user-mongodb:27017/?authSource=admin
+    depends_on:
+      user-mongodb:
+        condition: service_healthy
+    networks:
+      - api-gateway
+      - user-internal
+
+networks:
+  api-gateway:
+  user-internal:

--- a/user-service/docker-compose.yml
+++ b/user-service/docker-compose.yml
@@ -20,11 +20,12 @@ services:
       APP_PORT: 8000
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.user.rule=PathPrefix(`/api/users`)"
-      - "traefik.http.routers.user.middlewares=user-strip-prefix"
-      - "traefik.http.middlewares.user-strip-prefix.stripprefix.prefixes=/api/users"
-      - "traefik.http.middlewares.user-strip-prefix.stripprefix.forceslash=false"
-      - "traefik.http.services.user.loadbalancer.server.port=8000"
+      - "traefik.docker.network=api-gateway"
+      - "traefik.http.routers.user-service.rule=PathPrefix(`/api/users`)"
+      - "traefik.http.routers.user-service.middlewares=user-service-strip-prefix"
+      - "traefik.http.middlewares.user-service-strip-prefix.stripprefix.prefixes=/api/users"
+      - "traefik.http.middlewares.user-service-strip-prefix.stripprefix.forceslash=false"
+      - "traefik.http.services.user-service.loadbalancer.server.port=8000"
     depends_on:
       user-mongodb:
         condition: service_healthy
@@ -56,7 +57,6 @@ networks:
   api-gateway:
   # Creates a private network for this microservice
   user-internal:
-    internal: true
 
 volumes:
   user-mongo-data:

--- a/user-service/handlers/user_handler.go
+++ b/user-service/handlers/user_handler.go
@@ -167,7 +167,6 @@ func (h *UserHandler) HandleAccountVerification(w http.ResponseWriter, r *http.R
 
 	// handle account verification success
 	http.Redirect(w, r, VerificationSuccessUrl, http.StatusSeeOther)
-	return
 }
 
 func (h *UserHandler) HandleVerifyLoginOtp(w http.ResponseWriter, r *http.Request) {

--- a/user-service/services/mail_service.go
+++ b/user-service/services/mail_service.go
@@ -29,7 +29,7 @@ func (ms *MailService) sendAccountVerificationEmail(mailto string, token string)
 	m.Subject("Account verification")
 	// TODO: change domain to a environment variable...
 	m.SetBodyString(mail.TypeTextHTML,
-		fmt.Sprintf("<span>Click <a href='http://localhost:8000/verify?token=%s'>here</a> to verify your account.</span>", token))
+		fmt.Sprintf("<span>Click <a href='http://localhost:3000/api/users/verify?token=%s'>here</a> to verify your account.</span>", token))
 
 	if err := ms.c.DialAndSend(m); err != nil {
 		log.Fatalf("failed to send mail: %s", err)


### PR DESCRIPTION
- Adds a `user-service/docker-compose.dev.yml` file that serves the [Mongo Express](https://github.com/mongo-express/mongo-express).
- Mongo Express is accessible to `http://localhost:3000/dev/user-service` to access User Service's MongoDB.
- User Service's MongoDB is now exposed to port `3101` for direct access, useful for tool such as [MongoDB Shell (`mongosh`)](https://www.mongodb.com/docs/mongodb-shell/).

Please update your `.env` with new `.env.example` fields. 