### PR TITLE
Add Docker image and compose for Frontend

### DIFF
--- a/Dockerfile.microservice
+++ b/Dockerfile.microservice
@@ -1,5 +1,4 @@
-# Stage 1 (Build)
-FROM golang:1.25.5-alpine AS builder
+FROM golang:1.25.5-alpine AS build
 
 WORKDIR /app
 
@@ -19,11 +18,10 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 	-o /app/build.bin \
 	main.go
 
-# Stage 2 (Final)
 FROM gcr.io/distroless/static:latest
 
 WORKDIR /app
 
-COPY --from=builder /app/build.bin /usr/bin/service
+COPY --from=build /app/build.bin /usr/bin/service
 
 ENTRYPOINT ["/usr/bin/service"]

--- a/Dockerfile.microservice
+++ b/Dockerfile.microservice
@@ -1,4 +1,5 @@
-FROM golang:1.25.5-alpine AS build
+# Stage 1 (Build)
+FROM golang:1.25.5-alpine AS builder
 
 WORKDIR /app
 
@@ -18,10 +19,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 	-o /app/build.bin \
 	main.go
 
+# Stage 2 (Final)
 FROM gcr.io/distroless/static:latest
 
 WORKDIR /app
 
-COPY --from=build /app/build.bin /usr/bin/service
+COPY --from=builder /app/build.bin /usr/bin/service
 
 ENTRYPOINT ["/usr/bin/service"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -20,6 +20,26 @@ services:
       # In production, this will be its own accessible service, likely external.
       - api-gateway
 
+  # --- Frontend ---
+  # For hot reload
+
+  frontend:
+    command: npm run start -- --host 0.0.0.0 --port 3000
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    labels:
+      traefik.http.services.frontend.loadbalancer.server.port: "3000"
+    volumes:
+      - ./frontend/:/app
+      # keep node_modules in a separate volume, out of the bind mount
+      # this ensures that node_modules folder does not break permissions by Docker
+      # and quicker polling for source files
+      - frontend-node-modules:/app/node_modules
+    environment:
+      - CHOKIDAR_USEPOLLING=true # reliable file watching on Docker for Win/Mac
+      - NG_CLI_ANALYTICS=false # disable telemetry
+
   # --- User Service ---
   # For local development
 
@@ -30,11 +50,11 @@ services:
   user-mongo-express: # MongoDB GUI
     image: mongo-express:1
     labels:
-      - "traefik.enable=true"
-      - "traefik.docker.network=api-gateway"
-      - "traefik.http.routers.user-mongo-express.rule=PathPrefix(`/dev/user-service`)"
-      - "traefik.http.middlewares.user-mongo-express-strip-prefix.stripprefix.forceslash=false"
-      - "traefik.http.services.user-mongo-express.loadbalancer.server.port=8081"
+      traefik.enable: true
+      traefik.docker.network: api-gateway
+      traefik.http.routers.user-mongo-express.rule: PathPrefix(`/dev/user-service`)
+      traefik.http.middlewares.user-mongo-express-strip-prefix.stripprefix.forceslash: false
+      traefik.http.services.user-mongo-express.loadbalancer.server.port: 8081
     environment:
       ME_CONFIG_BASICAUTH: "false"
       ME_CONFIG_SITE_BASEURL: /dev/user-service
@@ -45,6 +65,9 @@ services:
     networks:
       - api-gateway
       - user-internal
+
+volumes:
+  frontend-node-modules:
 
 networks:
   api-gateway:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ networks:
   api-gateway:
 
 include:
+  - frontend/docker-compose.yml
   - user-service/docker-compose.yml
   # - content-service/docker-compose.yml
   # - ratings-service/docker-compose.yml
@@ -23,4 +24,3 @@ include:
   # - notifications-service/docker-compose.yml
   # - recommendation-service/docker-compose.yml
   # - analytics-service/docker-compose.yml
-  # - frontend/docker-compose.yml

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:24-alpine AS build
+WORKDIR /app
+
+COPY package*.json .
+RUN npm ci
+
+COPY . .
+RUN npm run build -- --configuration production
+
+FROM nginx:1.27-alpine AS runtime
+COPY --from=build /app/dist/spotlite/browser /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,10 +1,10 @@
 FROM node:24-alpine
 WORKDIR /app
 
+# We only need dependencies for development that is stored in its own volume
+# Source files are mounted from host machine without node_modules - avoiding any permissions issues
 COPY package*.json .
 RUN npm ci
-
-# COPY . .
 
 EXPOSE 3000
 CMD ["npm", "run", "start"]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,10 @@
+FROM node:24-alpine
+WORKDIR /app
+
+COPY package*.json .
+RUN npm ci
+
+# COPY . .
+
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    networks:
+      - api-gateway
+    labels:
+      traefik.enable: true
+      traefik.docker.network: api-gateway
+      traefik.http.routers.frontend.rule: PathPrefix(`/`)
+      traefik.http.services.frontend.loadbalancer.server.port: 80
+
+networks:
+  api-gateway:

--- a/user-service/docker-compose.yml
+++ b/user-service/docker-compose.yml
@@ -19,13 +19,13 @@ services:
       APP_LOGIN_OTP_TTL_MINUTES: ${SRV_USER_LOGIN_OTP_TTL_MINUTES?}
       APP_PORT: 3000
     labels:
-      - "traefik.enable=true"
-      - "traefik.docker.network=api-gateway"
-      - "traefik.http.routers.user-service.rule=PathPrefix(`/api/users`)"
-      - "traefik.http.routers.user-service.middlewares=user-service-strip-prefix"
-      - "traefik.http.middlewares.user-service-strip-prefix.stripprefix.prefixes=/api/users"
-      - "traefik.http.middlewares.user-service-strip-prefix.stripprefix.forceslash=false"
-      - "traefik.http.services.user-service.loadbalancer.server.port=3000"
+      traefik.enable: true
+      traefik.docker.network: api-gateway
+      traefik.http.routers.user-service.rule: PathPrefix(`/api/users`)
+      traefik.http.routers.user-service.middlewares: user-service-strip-prefix
+      traefik.http.middlewares.user-service-strip-prefix.stripprefix.prefixes: /api/users
+      traefik.http.middlewares.user-service-strip-prefix.stripprefix.forceslash: false
+      traefik.http.services.user-service.loadbalancer.server.port: 3000
     depends_on:
       user-mongodb:
         condition: service_healthy


### PR DESCRIPTION
Containerizes Frontend service to a container via API Gateway at `/` root and configures a development environment for hot reload on the website.

Note that working in `frontend` still requires to follow the `README.md` of the service to `npm install` inside it for development. The Docker dev image stores the `node_modules` in its image to prevent permission overriding.