### PR TITLE
Standarize 200 messages and logging failures

### DIFF
--- a/common-lib/respond/common.go
+++ b/common-lib/respond/common.go
@@ -1,0 +1,17 @@
+package respond
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+func writeJson(w http.ResponseWriter, statusCode int, payload any) error {
+	w.WriteHeader(statusCode)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		http.Error(w, "failed to write response", http.StatusInternalServerError)
+		return fmt.Errorf("failed to write response: %w", err)
+	}
+	return nil
+}

--- a/common-lib/respond/errors.go
+++ b/common-lib/respond/errors.go
@@ -28,8 +28,7 @@ func Error(w http.ResponseWriter, e ErrorResponse) error {
 		e.Message = http.StatusText(e.HttpCode)
 	}
 
-	writeJson(w, e.HttpCode, r)
-	return nil
+	return writeJson(w, e.HttpCode, r)
 }
 
 // ValidationError issues a validation error response with field-level details.

--- a/common-lib/respond/errors.go
+++ b/common-lib/respond/errors.go
@@ -1,8 +1,6 @@
 package respond
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 )
 
@@ -30,14 +28,7 @@ func Error(w http.ResponseWriter, e ErrorResponse) error {
 		e.Message = http.StatusText(e.HttpCode)
 	}
 
-	w.WriteHeader(e.HttpCode)
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(r); err != nil {
-		msg := fmt.Sprintf("failed to write response. Code '%d', Message: '%s'", e.HttpCode, e.Message)
-		http.Error(w, msg, http.StatusInternalServerError)
-		return fmt.Errorf("failed to write error response: %w", err)
-	}
-
+	writeJson(w, e.HttpCode, r)
 	return nil
 }
 

--- a/common-lib/respond/success.go
+++ b/common-lib/respond/success.go
@@ -1,0 +1,35 @@
+package respond
+
+import (
+	"net/http"
+)
+
+func writeMessageJson(w http.ResponseWriter, statusCode int, message string) error {
+	r := map[string]string{"message": message}
+	return writeJson(w, statusCode, r)
+}
+
+// OkJson sends a 200 OK response with the provided data as JSON.
+func OkJson(w http.ResponseWriter, data any) error {
+	return writeJson(w, http.StatusOK, data)
+}
+
+// Ok sends a 200 OK response with a message as JSON.
+func Ok(w http.ResponseWriter, message string) error {
+	return writeMessageJson(w, http.StatusOK, message)
+}
+
+// CreatedJson sends a 201 CreatedJson response with the provided data as JSON.
+func CreatedJson(w http.ResponseWriter, data any) error {
+	return writeJson(w, http.StatusCreated, data)
+}
+
+// Created sends a 201 Created response with a message as JSON.
+func Created(w http.ResponseWriter, message string) error {
+	return writeMessageJson(w, http.StatusCreated, message)
+}
+
+// NoContent sends a 204 No Content response.
+func NoContent(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/user-service/handlers/refresh_token_handler.go
+++ b/user-service/handlers/refresh_token_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"log"
 	"net/http"
 
@@ -23,8 +22,6 @@ func NewRefreshTokenHandler(rts services.RefreshTokenService, us services.UserSe
 }
 
 func (h *RefreshTokenHandler) HandleRefreshToken(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-
 	var req dtos.RefreshRequest
 	if ok, err := requests.ReadAndValidateJson(w, h.v, r.Body, &req); !ok {
 		if err != nil {
@@ -47,6 +44,7 @@ func (h *RefreshTokenHandler) HandleRefreshToken(w http.ResponseWriter, r *http.
 
 	access, err := h.us.CreateNewToken(r.Context(), user)
 	if err != nil {
+		log.Printf("failed to create new access token: %v", err)
 		_ = respond.InternalServerError(w)
 		return
 	}
@@ -55,7 +53,7 @@ func (h *RefreshTokenHandler) HandleRefreshToken(w http.ResponseWriter, r *http.
 		AccessToken: access,
 	}
 
-	if err := json.NewEncoder(w).Encode(b); err != nil {
-		_ = respond.InternalServerError(w)
+	if err := respond.OkJson(w, b); err != nil {
+		log.Printf("failed to write refresh token response: %v", err)
 	}
 }

--- a/user-service/handlers/user_handler.go
+++ b/user-service/handlers/user_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
@@ -34,8 +33,6 @@ func NewUserHandler(s services.UserService, v validator.Validate, rts services.R
 
 // HandleLogin authenticates user credentials and triggers OTP delivery.
 func (h *UserHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-
 	var req dtos.UserLoginDto
 	if ok, err := requests.ReadAndValidateJson(w, h.v, r.Body, &req); !ok {
 		if err != nil {
@@ -57,24 +54,18 @@ func (h *UserHandler) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		_ = respond.Unauthorized(w, "User is inactive.")
 		return
 	case err != nil:
+		log.Printf("failed to login user: %v", err)
 		_ = respond.InternalServerError(w)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(map[string]any{
-		"otp_required": true,
-		"message":      "OTP sent to email",
-	}); err != nil {
+	if err := respond.Ok(w, "OTP sent to email."); err != nil {
 		log.Printf("failed to write login response: %v", err)
-		http.Error(w, "failed to write response", http.StatusInternalServerError)
 	}
 }
 
 // HandleRegistration func, handles user registration requests and returns adequate responses.
 func (h *UserHandler) HandleRegistration(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-
 	// trying to decode the registration request dto
 	var req dtos.UserRegistrationDto
 	if ok, err := requests.ReadAndValidateJson(w, h.v, r.Body, &req); !ok {
@@ -100,11 +91,12 @@ func (h *UserHandler) HandleRegistration(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
+		log.Printf("failed to register user: %v", err)
 		_ = respond.InternalServerError(w)
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	respond.NoContent(w)
 }
 
 // HandleAccountVerification func, handles user account verification requests and redirects to success/failure pages
@@ -138,8 +130,6 @@ func (h *UserHandler) HandleAccountVerification(w http.ResponseWriter, r *http.R
 
 // HandleVerifyLoginOtp validates the OTP and issues a JWT token on success.
 func (h *UserHandler) HandleVerifyLoginOtp(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-
 	var req dtos.VerifyLoginOtpDto
 	if ok, err := requests.ReadAndValidateJson(w, h.v, r.Body, &req); !ok {
 		if err != nil {
@@ -156,18 +146,21 @@ func (h *UserHandler) HandleVerifyLoginOtp(w http.ResponseWriter, r *http.Reques
 	}
 
 	if err != nil {
+		log.Printf("failed to verify login otp: %v", err)
 		_ = respond.InternalServerError(w)
 		return
 	}
 
 	token, err := h.s.CreateNewToken(r.Context(), user)
 	if err != nil {
+		log.Printf("failed to create access token: %v", err)
 		_ = respond.InternalServerError(w)
 		return
 	}
 
 	refresh, err := h.rts.IssueRefreshToken(r.Context(), user.ID)
 	if err != nil {
+		log.Printf("failed to issue refresh token: %v", err)
 		_ = respond.InternalServerError(w)
 		return
 	}
@@ -177,7 +170,7 @@ func (h *UserHandler) HandleVerifyLoginOtp(w http.ResponseWriter, r *http.Reques
 		"refresh_token": refresh,
 	}
 
-	if err := json.NewEncoder(w).Encode(b); err != nil {
-		_ = respond.InternalServerError(w)
+	if err := respond.OkJson(w, b); err != nil {
+		log.Printf("failed to write verify login otp response: %v", err)
 	}
 }


### PR DESCRIPTION
- Replace manual JSON encodes handlers with `common-lib/respond` helpers.
- Remove explicit `Content-Type` headers (all handled in `common-lib`)
- Ensure all 500 responses are preceded by `log.Printf` so it logs the actual error in the console.
- On response write failures, log only without attempts to write again to potential closed stream.