### PR TITLE
Adds healthcheck to services

### DIFF
--- a/common-lib/middlewares/healthz.go
+++ b/common-lib/middlewares/healthz.go
@@ -1,0 +1,17 @@
+package middlewares
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/vanjmali/spotlite/common-lib/respond"
+)
+
+// HandleHealthz sets up a router with a /healthz endpoint for health checks.
+// It is for used internal monitoring purposes.
+func HandleHealthz(r *mux.Router) http.Handler {
+	r.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		_ = respond.OkJson(w, map[string]string{"status": "ok"})
+	}).Methods("GET")
+	return r
+}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -107,6 +107,9 @@ services:
       traefik.http.routers.user-mongo-express.rule: PathPrefix(`/dev/user-service`)
       traefik.http.middlewares.user-mongo-express-strip-prefix.stripprefix.forceslash: false
       traefik.http.services.user-mongo-express.loadbalancer.server.port: "8081"
+      traefik.http.services.user-mongo-express.loadbalancer.healthcheck.path: /dev/user-service
+      traefik.http.services.user-mongo-express.loadbalancer.healthcheck.interval: 5s
+      traefik.http.services.user-mongo-express.loadbalancer.healthcheck.timeout: 2s
     environment:
       ME_CONFIG_BASICAUTH: "false"
       ME_CONFIG_SITE_BASEURL: /dev/user-service

--- a/user-service/docker-compose.yml
+++ b/user-service/docker-compose.yml
@@ -32,6 +32,9 @@ services:
       traefik.http.middlewares.user-service-strip-prefix.stripprefix.prefixes: /api/users
       traefik.http.middlewares.user-service-strip-prefix.stripprefix.forceslash: false
       traefik.http.services.user-service.loadbalancer.server.port: "3000"
+      traefik.http.services.user-service.loadbalancer.healthcheck.path: /healthz
+      traefik.http.services.user-service.loadbalancer.healthcheck.interval: 5s
+      traefik.http.services.user-service.loadbalancer.healthcheck.timeout: 2s
     depends_on:
       user-mongodb:
         condition: service_healthy

--- a/user-service/go.mod
+++ b/user-service/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/wneessen/go-mail v0.7.2
 	go.mongodb.org/mongo-driver v1.17.6
 	go.opentelemetry.io/contrib/instrumentation/go.mongodb.org/mongo-driver/mongo/otelmongo v0.64.0
+	go.opentelemetry.io/otel v1.39.0
+	go.opentelemetry.io/otel/trace v1.39.0
 	golang.org/x/crypto v0.46.0
 )
 
@@ -37,12 +39,10 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.64.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/user-service/routers/router.go
+++ b/user-service/routers/router.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/vanjmali/spotlite/common-lib/middlewares"
 	"github.com/vanjmali/spotlite/common-lib/telemetry"
 	"github.com/vanjmali/spotlite/user-service/handlers"
 )
@@ -11,20 +12,25 @@ import (
 // HandleRequests wires HTTP routes to user handlers.
 func HandleRequests(h *handlers.UserHandler, rth *handlers.RefreshTokenHandler) http.Handler {
 	r := mux.NewRouter()
-	telemetry.AttachMuxTracing(r, "user-service")
+	middlewares.HandleHealthz(r)
 
-	r.HandleFunc("/register", h.HandleRegistration).Methods("POST")
+	// Create a subrouter for API routes to attach telemetry
+	// and other middlewares if needed.
+	api := r.PathPrefix("/").Subrouter()
+	telemetry.AttachMuxTracing(api, "user-service")
 
-	r.HandleFunc("/login", h.HandleLogin).Methods("POST")
-	r.HandleFunc("/login/verify-otp", h.HandleVerifyLoginOtp).Methods("POST")
-	r.HandleFunc("/login/resend-otp", h.HandleResendOtp).Methods("POST")
+	api.HandleFunc("/register", h.HandleRegistration).Methods("POST")
 
-	r.HandleFunc("/check-email/{email}", h.HandleCheckEmail).Methods("GET")
+	api.HandleFunc("/login", h.HandleLogin).Methods("POST")
+	api.HandleFunc("/login/verify-otp", h.HandleVerifyLoginOtp).Methods("POST")
+	api.HandleFunc("/login/resend-otp", h.HandleResendOtp).Methods("POST")
 
-	r.HandleFunc("/refresh-token", rth.HandleRefreshToken).Methods("POST")
+	api.HandleFunc("/check-email/{email}", h.HandleCheckEmail).Methods("GET")
 
-	// the verify endpoint is defined as a get so it can redirect when link click happens,
-	r.HandleFunc("/verify", h.HandleAccountVerification).Methods("GET", "POST")
+	api.HandleFunc("/refresh-token", rth.HandleRefreshToken).Methods("POST")
+
+	// the verify endpoint is defined as a get so it can redirect when link click happens.
+	api.HandleFunc("/verify", h.HandleAccountVerification).Methods("GET", "POST")
 
 	return r
 }


### PR DESCRIPTION
Adds `/healthz` path used by the API Gateway to check when services are up via periodical health checks. This will also ensure the Gateway is aware when service restarts.

This handler is added to `common-lib` and is outside of tracers. API routes use a sub-router for this.