### PR TITLE
Statically use `api-gateway` Docker network

### DIFF
--- a/api-gateway/traefik.dev.yml
+++ b/api-gateway/traefik.dev.yml
@@ -11,7 +11,7 @@ entryPoints:
 providers:
   docker:
     exposedByDefault: false
-    network: api-gateway
+    network: spotlite-api-gateway
 
 api:
   dashboard: true

--- a/api-gateway/traefik.yml
+++ b/api-gateway/traefik.yml
@@ -21,7 +21,7 @@ providers:
     # Only expose services that set `traefik.enable=true`.
     exposedByDefault: false
     # Watch containers on this network.
-    network: api-gateway
+    network: spotlite-api-gateway
 
 api:
   # Traefik dashboard/API; stay off in prod (overridden on in dev).

--- a/content-service/docker-compose.yml
+++ b/content-service/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
     labels:
       traefik.enable: true
-      traefik.docker.network: api-gateway
+      traefik.docker.network: spotlite-api-gateway
       traefik.http.routers.content-service.rule: PathPrefix(`/api/content`)
       traefik.http.routers.content-service.middlewares: content-service-strip-prefix
       traefik.http.middlewares.content-service-strip-prefix.stripprefix.prefixes: /api/content
@@ -53,6 +53,7 @@ services:
 
 networks:
   api-gateway:
+    name: spotlite-api-gateway
   content-internal:
 
 volumes:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,7 +18,7 @@ services:
     image: jaegertracing/all-in-one:1.75.0
     labels:
       traefik.enable: true
-      traefik.docker.network: api-gateway
+      traefik.docker.network: spotlite-api-gateway
       traefik.http.routers.jaeger.rule: PathPrefix(`/dev/jaeger`)
       traefik.http.middlewares.jaeger-strip-prefix.stripprefix.prefixes: /dev/jaeger
       traefik.http.middlewares.jaeger-strip-prefix.stripprefix.forceslash: false
@@ -113,7 +113,7 @@ services:
     image: mongo-express:1
     labels:
       traefik.enable: true
-      traefik.docker.network: api-gateway
+      traefik.docker.network: spotlite-api-gateway
       traefik.http.routers.user-mongo-express.rule: PathPrefix(`/dev/user-service`)
       traefik.http.routers.user-mongo-express.middlewares: user-mongo-express-strip-prefix
       traefik.http.middlewares.user-mongo-express-strip-prefix.stripprefix.forceslash: false
@@ -139,7 +139,7 @@ services:
     image: mongo-express:1
     labels:
       traefik.enable: true
-      traefik.docker.network: api-gateway
+      traefik.docker.network: spotlite-api-gateway
       traefik.http.routers.content-mongo-express.rule: PathPrefix(`/dev/content-service`)
       traefik.http.routers.content-mongo-express.middlewares: content-mongo-express-strip-prefix
       traefik.http.middlewares.content-mongo-express-strip-prefix.stripprefix.forceslash: false
@@ -168,4 +168,5 @@ volumes:
 
 networks:
   api-gateway:
+    name: spotlite-api-gateway
   user-internal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
 
 networks:
   api-gateway:
+    name: spotlite-api-gateway
 
 include:
   - frontend/docker-compose.yml

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -7,9 +7,10 @@ services:
       - api-gateway
     labels:
       traefik.enable: true
-      traefik.docker.network: api-gateway
+      traefik.docker.network: spotlite-api-gateway
       traefik.http.routers.frontend.rule: PathPrefix(`/`)
       traefik.http.services.frontend.loadbalancer.server.port: '80'
 
 networks:
   api-gateway:
+    name: spotlite-api-gateway

--- a/notification-service/docker-compose.yml
+++ b/notification-service/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
     labels:
       traefik.enable: true
-      traefik.docker.network: api-gateway
+      traefik.docker.network: spotlite-api-gateway
       traefik.http.routers.notification-service.rule: PathPrefix(`/api/notifications`)
       traefik.http.routers.notification-service.middlewares: notification-service-strip-prefix,notification-service-compress
       traefik.http.middlewares.notification-service-strip-prefix.stripprefix.prefixes: /api/notifications
@@ -81,6 +81,7 @@ services:
 networks:
   # Connects to Traefik
   api-gateway:
+    name: spotlite-api-gateway
   # Creates a private network for this microservice
   notification-internal:
 

--- a/user-service/docker-compose.yml
+++ b/user-service/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
     labels:
       traefik.enable: true
-      traefik.docker.network: api-gateway
+      traefik.docker.network: spotlite-api-gateway
       traefik.http.routers.user-service.rule: PathPrefix(`/api/users`)
       traefik.http.routers.user-service.middlewares: user-service-strip-prefix
       traefik.http.middlewares.user-service-strip-prefix.stripprefix.prefixes: /api/users
@@ -89,6 +89,7 @@ services:
 networks:
   # Connects to Traefik
   api-gateway:
+    name: spotlite-api-gateway
   # Creates a private network for this microservice
   user-internal:
 


### PR DESCRIPTION
Resolves unknown 503 errors that was reading the wrong network on requests leading to unexpected behaviour.

Fixes #51