### PR TITLE
Properly display `fields` property for failed request body validations

### DIFF
--- a/common-lib/requests/validate.go
+++ b/common-lib/requests/validate.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
+	"strings"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/vanjmali/spotlite/common-lib/respond"
@@ -29,6 +31,21 @@ var customValidationMessages map[string]ValidatorCustomMessage = make(map[string
 // RegisterValidationMessage registers a custom error message for a validation tag.
 func RegisterValidationMessage(tag string, msg ValidatorCustomMessage) {
 	customValidationMessages[tag] = msg
+}
+
+// RegisterJSONTagNameFunc configures the validator to use JSON tag names for field errors.
+// Fields tagged with json:"-" return an empty name and will be skipped by the validator.
+func RegisterJSONTagNameFunc(v *validator.Validate) {
+	v.RegisterTagNameFunc(func(fld reflect.StructField) string {
+		name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+		if name == "-" {
+			return ""
+		}
+		if name == "" {
+			return fld.Name
+		}
+		return name
+	})
 }
 
 // RegisterValidation registers a custom validator with the given validator instance.

--- a/common-lib/respond/errors.go
+++ b/common-lib/respond/errors.go
@@ -22,6 +22,7 @@ func Error(w http.ResponseWriter, e ErrorResponse) error {
 	r := ErrorResponse{
 		Code:    e.Code,
 		Message: e.Message,
+		Fields:  e.Fields,
 	}
 
 	if e.Message == "" {

--- a/content-service/main.go
+++ b/content-service/main.go
@@ -56,6 +56,7 @@ func run() error {
 	// Configure validators
 	requests.RegisterCommonValidationMessages()
 	v := validator.New()
+	requests.RegisterJSONTagNameFunc(v)
 	if err := requests.RegisterValidation(v, commonvalid.CheckValidName); err != nil {
 		return fmt.Errorf("failed to register custom validations: %w", err)
 	}

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -69,6 +69,7 @@ func run() error {
 	// Configure validators
 	requests.RegisterCommonValidationMessages()
 	v := validator.New()
+	requests.RegisterJSONTagNameFunc(v)
 
 	if err := requests.RegisterValidation(v, validation.CheckStrongPassword); err != nil {
 		return fmt.Errorf("failed to register custom validations: %w", err)


### PR DESCRIPTION
Correctly sets `fields` property to the response body when a validation error occurs with details why it is a bad request.

### Example Response

```json
{
	"code": "validation_error",
	"message": "One or more fields have validation errors.",
	"fields": {
		"email": "email is required",
		"first_name": "first_name is required",
		"last_name": "last_name is required",
		"password": "password is required",
		"username": "username is required"
	}
}
```

