### PR TITLE
Ensure non-root users are used for production Docker images

### DIFF
--- a/Dockerfile.microservice
+++ b/Dockerfile.microservice
@@ -29,10 +29,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 	-o /app/build.bin \
 	main.go
 
-FROM gcr.io/distroless/static:latest
+FROM gcr.io/distroless/static:nonroot
 
 WORKDIR /app
 
 COPY --from=build /app/build.bin /usr/bin/service
+
+USER nonroot
 
 ENTRYPOINT ["/usr/bin/service"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ RUN npm ci
 COPY . .
 RUN npm run build -- --configuration production
 
-FROM nginx:1.27-alpine AS runtime
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
 COPY --from=build /app/dist/spotlite/browser /usr/share/nginx/html
-EXPOSE 80
+EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       traefik.enable: true
       traefik.docker.network: spotlite-api-gateway
       traefik.http.routers.frontend.rule: PathPrefix(`/`)
-      traefik.http.services.frontend.loadbalancer.server.port: '80'
+      traefik.http.services.frontend.loadbalancer.server.port: '8080'
 
 networks:
   api-gateway:


### PR DESCRIPTION
Replaces base Docker images for nonroot variants.

Fixes #39 