### PR TITLE
Use `debian13` on a pinned tag build from gcr.io

### DIFF
--- a/Dockerfile.microservice
+++ b/Dockerfile.microservice
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 	-o /app/build.bin \
 	main.go
 
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static-debian13:nonroot-6c3a3ad900dcad1202479fe2055384c46c47ad5c
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes #40