### PR TITLE
add validation for empty values in update endpoints

### DIFF
--- a/content-service/dtos/album_dto.go
+++ b/content-service/dtos/album_dto.go
@@ -16,8 +16,8 @@ type CreateAlbumDto struct {
 
 // UpdateAlbumDto represents the payload for updating an existing album. Pointers allow partial updates.
 type UpdateAlbumDto struct {
-	Title       *string   `json:"title" validate:"omitempty,min=2,max=100"`
-	ReleaseDate *string   `json:"release_date" validate:"omitempty,len=10"` // Date string in YYYY-MM-DD format
+	Title       *string   `json:"title" validate:"omitempty,required,min=2,max=100"`
+	ReleaseDate *string   `json:"release_date" validate:"omitempty,required,len=10"` // Date string in YYYY-MM-DD format
 	GenreIds    *[]string `json:"genre_ids" validate:"omitempty,min=1,dive,required,len=24,hexadecimal"`
 	ArtistIds   *[]string `json:"artist_ids" validate:"omitempty,min=1,dive,required,len=24,hexadecimal"`
 }

--- a/content-service/dtos/artist_dto.go
+++ b/content-service/dtos/artist_dto.go
@@ -16,9 +16,9 @@ type ArtistDto struct {
 
 // UpdateArtistDto represents the payload for updating an existing artist. Pointers allow partial updates.
 type UpdateArtistDto struct {
-	Name        *string   `json:"name" validate:"omitempty,min=2"`
+	Name        *string   `json:"name" validate:"omitempty,required,min=2"`
 	GenreIds    *[]string `json:"genre_ids" validate:"omitempty,min=1,dive,required,len=24,hexadecimal"`
-	Description *string   `json:"description" validate:"omitempty,min=2"`
+	Description *string   `json:"description" validate:"omitempty,required,min=2"`
 }
 
 // ArtistListResponseDto represents the response payload when returning a paginated list of artists.

--- a/content-service/dtos/song_dto.go
+++ b/content-service/dtos/song_dto.go
@@ -15,7 +15,7 @@ type SongDto struct {
 
 // UpdateSongDto represents the payload for updating an existing song. Pointers allow partial updates.
 type UpdateSongDto struct {
-	Title         *string   `json:"title" validate:"omitempty,min=2"`
+	Title         *string   `json:"title" validate:"omitempty,required,min=2"`
 	GenreIds      *[]string `json:"genre_ids" validate:"omitempty,min=1,dive,required,len=24,hexadecimal"`
 	LengthSeconds *int      `json:"length_seconds" validate:"omitempty,gt=0"`
 	ArtistIds     *[]string `json:"artist_ids" validate:"omitempty,min=1,dive,required,len=24,hexadecimal"`

--- a/content-service/handlers/album_handler.go
+++ b/content-service/handlers/album_handler.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
@@ -182,18 +181,13 @@ func (h *AlbumHandler) HandleUpdateAlbum(w http.ResponseWriter, r *http.Request)
 	id := vars["id"]
 
 	var dto dtos.UpdateAlbumDto
-	if err := json.NewDecoder(r.Body).Decode(&dto); err != nil {
-		log.Printf("trace_id=%s failed to decode request body: %v", telemetry.TraceID(r.Context()), err)
-		_ = respond.BadRequest(w, "invalid request body")
+	if ok, err := requests.ReadAndValidateJson(w, h.v, r.Body, &dto); !ok {
+		if err != nil {
+			log.Printf("trace_id=%s invalid request body: %v", telemetry.TraceID(r.Context()), err)
+			_ = respond.BadRequest(w, "invalid request body")
+		}
 		return
 	}
-
-	if err := h.v.Struct(dto); err != nil {
-		log.Printf("trace_id=%s failed to validate update album request: %v", telemetry.TraceID(r.Context()), err)
-		_ = respond.BadRequest(w, "invalid request body")
-		return
-	}
-
 	updatedAlbum, err := h.s.UpdateAlbum(r.Context(), id, dto)
 	switch {
 	case errors.Is(err, services.ErrObjectIdCastFailed):

--- a/content-service/handlers/album_handler.go
+++ b/content-service/handlers/album_handler.go
@@ -188,6 +188,12 @@ func (h *AlbumHandler) HandleUpdateAlbum(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if err := h.v.Struct(dto); err != nil {
+		log.Printf("trace_id=%s failed to validate update album request: %v", telemetry.TraceID(r.Context()), err)
+		_ = respond.BadRequest(w, "invalid request body")
+		return
+	}
+
 	updatedAlbum, err := h.s.UpdateAlbum(r.Context(), id, dto)
 	switch {
 	case errors.Is(err, services.ErrObjectIdCastFailed):

--- a/content-service/handlers/artist_handler.go
+++ b/content-service/handlers/artist_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
@@ -82,15 +81,11 @@ func (h *ArtistHandler) HandleUpdateArtist(w http.ResponseWriter, r *http.Reques
 	id := vars["id"]
 
 	var dto dtos.UpdateArtistDto
-	if err := json.NewDecoder(r.Body).Decode(&dto); err != nil {
-		log.Printf("trace_id=%s failed to decode request body: %v", telemetry.TraceID(r.Context()), err)
-		_ = respond.BadRequest(w, "invalid request body")
-		return
-	}
-
-	if err := h.v.Struct(dto); err != nil {
-		log.Printf("trace_id=%s failed to validate update artist request: %v", telemetry.TraceID(r.Context()), err)
-		_ = respond.BadRequest(w, "invalid request body")
+	if ok, err := requests.ReadAndValidateJson(w, h.v, r.Body, &dto); !ok {
+		if err != nil {
+			log.Printf("trace_id=%s invalid request body: %v", telemetry.TraceID(r.Context()), err)
+			_ = respond.BadRequest(w, "invalid request body")
+		}
 		return
 	}
 

--- a/content-service/handlers/artist_handler.go
+++ b/content-service/handlers/artist_handler.go
@@ -88,6 +88,12 @@ func (h *ArtistHandler) HandleUpdateArtist(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	if err := h.v.Struct(dto); err != nil {
+		log.Printf("trace_id=%s failed to validate update artist request: %v", telemetry.TraceID(r.Context()), err)
+		_ = respond.BadRequest(w, "invalid request body")
+		return
+	}
+
 	updatedArtist, err := h.s.UpdateArtist(r.Context(), id, dto)
 	switch {
 	case errors.Is(err, services.ErrObjectIdCastFailed):

--- a/content-service/handlers/song_handler.go
+++ b/content-service/handlers/song_handler.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
@@ -92,15 +91,11 @@ func (h *SongHandler) HandleUpdateSong(w http.ResponseWriter, r *http.Request) {
 	id := vars["id"]
 
 	var dto dtos.UpdateSongDto
-	if err := json.NewDecoder(r.Body).Decode(&dto); err != nil {
-		log.Printf("trace_id=%s failed to decode request body: %v", telemetry.TraceID(r.Context()), err)
-		_ = respond.BadRequest(w, "invalid request body")
-		return
-	}
-
-	if err := h.v.Struct(dto); err != nil {
-		log.Printf("trace_id=%s failed to validate update song request: %v", telemetry.TraceID(r.Context()), err)
-		_ = respond.BadRequest(w, "invalid request body")
+	if ok, err := requests.ReadAndValidateJson(w, h.v, r.Body, &dto); !ok {
+		if err != nil {
+			log.Printf("trace_id=%s invalid request body: %v", telemetry.TraceID(r.Context()), err)
+			_ = respond.BadRequest(w, "invalid request body")
+		}
 		return
 	}
 

--- a/content-service/handlers/song_handler.go
+++ b/content-service/handlers/song_handler.go
@@ -98,6 +98,12 @@ func (h *SongHandler) HandleUpdateSong(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := h.v.Struct(dto); err != nil {
+		log.Printf("trace_id=%s failed to validate update song request: %v", telemetry.TraceID(r.Context()), err)
+		_ = respond.BadRequest(w, "invalid request body")
+		return
+	}
+
 	updatedSong, err := h.s.UpdateSong(r.Context(), id, dto)
 	switch {
 	case errors.Is(err, services.ErrObjectIdCastFailed):


### PR DESCRIPTION
Fix: Prevent blank values in content service updates

Added missing validation that was allowing fields to be updated with empty values.