### PR TITLE
Increase interval for MongoDB Docker Compose healthcheck

### DIFF
--- a/content-service/docker-compose.yml
+++ b/content-service/docker-compose.yml
@@ -43,11 +43,12 @@ services:
       test:
         [
           "CMD-SHELL",
-          'mongosh --username $$MONGO_INITDB_ROOT_USERNAME --password $$MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase admin --eval ''db.adminCommand("ping")''',
+          'mongosh --norc --quiet --username $$MONGO_INITDB_ROOT_USERNAME --password $$MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase admin --eval ''db.runCommand({ ping: 1 })''',
         ]
-      interval: 3s
+      interval: 30s
       timeout: 5s
       retries: 10
+      start_period: 20s
     volumes:
       - content-mongo-data:/data/db
       - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro

--- a/subscription-service/docker-compose.yml
+++ b/subscription-service/docker-compose.yml
@@ -45,11 +45,12 @@ services:
       test:
         [
           "CMD-SHELL",
-          'mongosh --username $$MONGO_INITDB_ROOT_USERNAME --password $$MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase admin --eval ''db.adminCommand("ping")''',
+          'mongosh --norc --quiet --username $$MONGO_INITDB_ROOT_USERNAME --password $$MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase admin --eval ''db.runCommand({ ping: 1 })''',
         ]
-      interval: 3s
+      interval: 30s
       timeout: 5s
       retries: 5
+      start_period: 20s
     volumes:
       - subscription-mongo-data:/data/db
       - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro

--- a/user-service/docker-compose.yml
+++ b/user-service/docker-compose.yml
@@ -63,11 +63,12 @@ services:
       test:
         [
           "CMD-SHELL",
-          'mongosh --username $$MONGO_INITDB_ROOT_USERNAME --password $$MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase admin --eval ''db.adminCommand("ping")''',
+          'mongosh --norc --quiet --username $$MONGO_INITDB_ROOT_USERNAME --password $$MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase admin --eval ''db.runCommand({ ping: 1 })''',
         ]
-      interval: 3s
+      interval: 30s
       timeout: 5s
       retries: 5
+      start_period: 20s
     volumes:
       - user-mongo-data:/data/db
       - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro


### PR DESCRIPTION
`mongosh` causes a CPU spike when doing a healthcheck.

This PR increases the interval for healthchecks for MongoDB services to reduce the CPU usage. 