### PR TITLE
Use ffmpeg to detect audio length

### DIFF
--- a/content-service/Dockerfile
+++ b/content-service/Dockerfile
@@ -1,0 +1,43 @@
+FROM golang:1.25.5-alpine AS build
+
+# Build common-lib package
+WORKDIR /common-lib
+
+COPY --from=common-lib go.mod ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+	--mount=type=cache,target=/root/.cache/go-build \
+	go mod download
+
+COPY --from=common-lib ./ ./
+
+# Build app-service binary
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+	--mount=type=cache,target=/root/.cache/go-build \
+	go mod download
+
+COPY ./ ./
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+	--mount=type=cache,target=/root/.cache/go-build \
+	CGO_ENABLED=0 go build \
+	-ldflags="-s -w" \
+	-v \
+	-trimpath \
+	-o /app/build.bin \
+	main.go
+
+FROM alpine:3.21
+
+RUN apk add --no-cache ffmpeg ca-certificates
+
+WORKDIR /app
+
+COPY --from=build /app/build.bin /usr/bin/service
+
+RUN addgroup -S app && adduser -S app -G app
+USER app
+
+ENTRYPOINT ["/usr/bin/service"]

--- a/content-service/README.md
+++ b/content-service/README.md
@@ -35,6 +35,9 @@ Optional base URL override (default is `http://localhost:3000/api/content`):
 E2E_BASE_URL=http://localhost:3000/api/content go test -tags e2e ./e2e -run TestAudioFlowE2E -v
 ```
 
+> [!NOTE]
+> `content-service` derives `length_seconds` with `ffprobe`, so runtime image/environment must have `ffprobe` available.
+
 ## Structure
 
 The purpose of this service is to handle the management and retrieval of music content entities:

--- a/content-service/docker-compose.yml
+++ b/content-service/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       additional_contexts:
         common-lib: ../common-lib
-      dockerfile: ../Dockerfile.microservice
+      dockerfile: ./Dockerfile
     environment:
       APP_PORT: 3000
       DB_HOST: content-mongodb

--- a/content-service/dtos/song_dto.go
+++ b/content-service/dtos/song_dto.go
@@ -7,19 +7,17 @@ import (
 
 // SongDto represents the data transfer object for a song entity.
 type SongDto struct {
-	Title         string   `json:"title" validate:"required,min=2"`
-	AlbumId       string   `json:"album_id" validate:"required,len=24,hexadecimal"`
-	GenreIds      []string `json:"genre_ids" validate:"required,min=1,dive,required,len=24,hexadecimal"`
-	LengthSeconds int      `json:"length_seconds" validate:"required,gt=0"`
-	ArtistIds     []string `json:"artist_ids" validate:"required,min=1,dive,required,len=24,hexadecimal"`
+	Title     string   `json:"title" validate:"required,min=2"`
+	AlbumId   string   `json:"album_id" validate:"required,len=24,hexadecimal"`
+	GenreIds  []string `json:"genre_ids" validate:"required,min=1,dive,required,len=24,hexadecimal"`
+	ArtistIds []string `json:"artist_ids" validate:"required,min=1,dive,required,len=24,hexadecimal"`
 }
 
 // UpdateSongDto represents the payload for updating an existing song. Pointers allow partial updates.
 type UpdateSongDto struct {
-	Title         *string   `json:"title" validate:"omitempty,required,min=2"`
-	GenreIds      *[]string `json:"genre_ids" validate:"omitempty,min=1,dive,required,len=24,hexadecimal"`
-	LengthSeconds *int      `json:"length_seconds" validate:"omitempty,gt=0"`
-	ArtistIds     *[]string `json:"artist_ids" validate:"omitempty,min=1,dive,required,len=24,hexadecimal"`
+	Title     *string   `json:"title" validate:"omitempty,required,min=2"`
+	GenreIds  *[]string `json:"genre_ids" validate:"omitempty,min=1,dive,required,len=24,hexadecimal"`
+	ArtistIds *[]string `json:"artist_ids" validate:"omitempty,min=1,dive,required,len=24,hexadecimal"`
 }
 
 // SongListResponseDto represents the response payload when returning a paginated list of songs.

--- a/content-service/e2e/audio_flow_e2e_test.go
+++ b/content-service/e2e/audio_flow_e2e_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -90,11 +91,10 @@ func TestAudioFlowE2E(t *testing.T) {
 
 	audioV1 := minimalWAVBytes([]byte("first-audio-payload"))
 	meta := map[string]any{
-		"title":          songTitle,
-		"album_id":       albumID,
-		"genre_ids":      []string{genreID},
-		"length_seconds": 123,
-		"artist_ids":     []string{artistID},
+		"title":      songTitle,
+		"album_id":   albumID,
+		"genre_ids":  []string{genreID},
+		"artist_ids": []string{artistID},
 	}
 	created := createSongWithAudio(t, client, baseURL+"/songs", meta, "track.wav", audioV1)
 	if created.ID == "" {
@@ -258,13 +258,31 @@ func findOneByField[T any](t *testing.T, client *http.Client, endpoint, key, val
 }
 
 func minimalWAVBytes(payload []byte) []byte {
-	header := []byte{
-		'R', 'I', 'F', 'F',
-		0x24, 0x00, 0x00, 0x00,
-		'W', 'A', 'V', 'E',
-		'f', 'm', 't', ' ',
+	if len(payload) > int(^uint32(0)) {
+		panic("payload too large")
 	}
-	return append(header, payload...)
+	dataSize := uint32(len(payload))
+	chunkSize := uint32(36) + dataSize
+	byteRate := uint32(8000 * 2) // 8kHz * mono * 16-bit
+	blockAlign := uint16(2)
+
+	buf := make([]byte, 44+len(payload))
+	copy(buf[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(buf[4:8], chunkSize)
+	copy(buf[8:12], "WAVE")
+	copy(buf[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(buf[16:20], 16)
+	binary.LittleEndian.PutUint16(buf[20:22], 1) // PCM
+	binary.LittleEndian.PutUint16(buf[22:24], 1) // mono
+	binary.LittleEndian.PutUint32(buf[24:28], 8000)
+	binary.LittleEndian.PutUint32(buf[28:32], byteRate)
+	binary.LittleEndian.PutUint16(buf[32:34], blockAlign)
+	binary.LittleEndian.PutUint16(buf[34:36], 16)
+	copy(buf[36:40], "data")
+	binary.LittleEndian.PutUint32(buf[40:44], dataSize)
+	copy(buf[44:], payload)
+
+	return buf
 }
 
 func assertSHA256Hex(t *testing.T, got string, payload []byte) {

--- a/content-service/handlers/song_handler.go
+++ b/content-service/handlers/song_handler.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"mime/multipart"
 	"net/http"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -469,6 +470,21 @@ func detectAudioDurationSeconds(file multipart.File, mime string) (*int, error) 
 	}
 	defer file.Seek(0, io.SeekStart)
 
+	tmp, err := os.CreateTemp("", "song-audio-*.bin")
+	if err != nil {
+		return nil, errors.New("failed to read audio duration")
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := io.Copy(tmp, file); err != nil {
+		_ = tmp.Close()
+		return nil, errors.New("failed to read audio duration")
+	}
+	if err := tmp.Close(); err != nil {
+		return nil, errors.New("failed to read audio duration")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -478,14 +494,11 @@ func detectAudioDurationSeconds(file multipart.File, mime string) (*int, error) 
 		"-v", "error",
 		"-show_entries", "format=duration",
 		"-of", "default=noprint_wrappers=1:nokey=1",
-		"-i", "pipe:0",
+		tmpPath,
 	)
-	cmd.Stdin = file
 
 	var stdout bytes.Buffer
-	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
 		return nil, errors.New("failed to read audio duration")

--- a/content-service/handlers/song_handler.go
+++ b/content-service/handlers/song_handler.go
@@ -9,9 +9,13 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"mime/multipart"
 	"net/http"
+	"os/exec"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gorilla/mux"
@@ -51,6 +55,8 @@ var (
 	errMultipartTooLarge    = errors.New("multipart payload too large")
 	errInvalidMultipartForm = errors.New("invalid multipart form")
 )
+
+var audioDurationDetector = detectAudioDurationSeconds
 
 // NewSongHandler creates and returns a new SongHandler with the provided service and validator.
 func NewSongHandler(s services.SongService, v validator.Validate) *SongHandler {
@@ -185,13 +191,13 @@ func (h *SongHandler) HandleUploadSongAudio(w http.ResponseWriter, r *http.Reque
 
 	id := mux.Vars(r)["id"]
 
-	file, reader, ext, mime, ok := getSingleValidatedAudioUpload(w, r)
+	file, reader, ext, mime, lengthSeconds, ok := getSingleValidatedAudioUpload(w, r)
 	if !ok {
 		return
 	}
 	defer file.Close()
 
-	updated, err := h.s.UploadAudio(r.Context(), id, reader, ext, mime)
+	updated, err := h.s.UploadAudio(r.Context(), id, reader, ext, mime, lengthSeconds)
 	if err != nil {
 		switch {
 		case errors.Is(err, services.ErrSongNotFound):
@@ -298,7 +304,7 @@ func (h *SongHandler) HandleCreateSongWithAudio(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	file, reader, ext, mime, ok := getSingleValidatedAudioUpload(w, r)
+	file, reader, ext, mime, lengthSeconds, ok := getSingleValidatedAudioUpload(w, r)
 	if !ok {
 		return
 	}
@@ -317,7 +323,7 @@ func (h *SongHandler) HandleCreateSongWithAudio(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	updated, err := h.s.UploadAudio(r.Context(), id.Hex(), reader, ext, mime)
+	updated, err := h.s.UploadAudio(r.Context(), id.Hex(), reader, ext, mime, lengthSeconds)
 	if err != nil {
 		if rollbackErr := h.s.DeleteSong(r.Context(), id.Hex()); rollbackErr != nil {
 			logSecurityEvent(r.Context(), "create_with_audio_rollback_failed", fmt.Sprintf("song_id=%s error=%v", id.Hex(), rollbackErr))
@@ -351,12 +357,12 @@ func parseMultipartWithLimit(w http.ResponseWriter, r *http.Request) error {
 
 // getSingleValidatedAudioUpload enforces one file input, verifies audio type from magic bytes,
 // and rebuilds a full reader (sniffed bytes + remaining stream) for downstream upload.
-func getSingleValidatedAudioUpload(w http.ResponseWriter, r *http.Request) (multipart.File, io.Reader, string, string, bool) {
+func getSingleValidatedAudioUpload(w http.ResponseWriter, r *http.Request) (multipart.File, io.Reader, string, string, *int, bool) {
 	mf := r.MultipartForm
 	if mf == nil || mf.File == nil {
 		logSecurityEvent(r.Context(), "upload_rejected_missing_file", "reason=no_file_part")
 		_ = respond.BadRequest(w, "missing file")
-		return nil, nil, "", "", false
+		return nil, nil, "", "", nil, false
 	}
 
 	totalFiles := 0
@@ -366,19 +372,19 @@ func getSingleValidatedAudioUpload(w http.ResponseWriter, r *http.Request) (mult
 	if totalFiles != 1 {
 		logSecurityEvent(r.Context(), "upload_rejected_multiple_files", fmt.Sprintf("count=%d", totalFiles))
 		_ = respond.BadRequest(w, "request must contain exactly one file")
-		return nil, nil, "", "", false
+		return nil, nil, "", "", nil, false
 	}
 	if len(mf.File["file"]) != 1 {
 		logSecurityEvent(r.Context(), "upload_rejected_invalid_file_field", "field=file")
 		_ = respond.BadRequest(w, "exactly one file must be provided under field 'file'")
-		return nil, nil, "", "", false
+		return nil, nil, "", "", nil, false
 	}
 
 	file, header, err := r.FormFile("file")
 	if err != nil {
 		logSecurityEvent(r.Context(), "upload_rejected_missing_file", "reason=form_file_error")
 		_ = respond.BadRequest(w, "missing file")
-		return nil, nil, "", "", false
+		return nil, nil, "", "", nil, false
 	}
 
 	sniff, err := readFileSniff(file)
@@ -386,14 +392,29 @@ func getSingleValidatedAudioUpload(w http.ResponseWriter, r *http.Request) (mult
 		logSecurityEvent(r.Context(), "upload_rejected_invalid_file", "reason="+err.Error())
 		_ = respond.BadRequest(w, err.Error())
 		_ = file.Close()
-		return nil, nil, "", "", false
+		return nil, nil, "", "", nil, false
 	}
 
 	ext, mime, badRequestMessage, ok := validateAudioFileSniff(r.Context(), sniff, header.Filename)
 	if !ok {
 		_ = respond.BadRequest(w, badRequestMessage)
 		_ = file.Close()
-		return nil, nil, "", "", false
+		return nil, nil, "", "", nil, false
+	}
+
+	lengthSeconds, err := audioDurationDetector(file, mime)
+	if err != nil {
+		logSecurityEvent(r.Context(), "upload_rejected_audio_duration_detection_failed", fmt.Sprintf("filename=%q mime=%s", header.Filename, mime))
+		_ = respond.BadRequest(w, err.Error())
+		_ = file.Close()
+		return nil, nil, "", "", nil, false
+	}
+
+	if _, err := file.Seek(int64(len(sniff)), io.SeekStart); err != nil {
+		logSecurityEvent(r.Context(), "upload_rejected_invalid_file", "reason=failed to reset file cursor")
+		_ = respond.BadRequest(w, "failed to read file")
+		_ = file.Close()
+		return nil, nil, "", "", nil, false
 	}
 
 	log.Printf("trace_id=%s uploaded file: name=%q, size=%d, mime=%s, extension=%s",
@@ -401,7 +422,7 @@ func getSingleValidatedAudioUpload(w http.ResponseWriter, r *http.Request) (mult
 
 	// file.Read already consumed sniff bytes; prepend them so upload reads the entire original file.
 	reader := io.MultiReader(bytes.NewReader(sniff), file)
-	return file, reader, ext, mime, true
+	return file, reader, ext, mime, lengthSeconds, true
 }
 
 // readFileSniff reads up to 512 header bytes used for content-type detection by magic bytes.
@@ -438,6 +459,50 @@ func validateAudioFileSniff(ctx context.Context, sniff []byte, filename string) 
 	}
 
 	return ext, mime, "", true
+}
+
+// detectAudioDurationSeconds derives audio duration from file metadata/header.
+// ffprobe is used to support all allowed audio formats.
+func detectAudioDurationSeconds(file multipart.File, mime string) (*int, error) {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, errors.New("failed to read audio duration")
+	}
+	defer file.Seek(0, io.SeekStart)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(
+		ctx,
+		"ffprobe",
+		"-v", "error",
+		"-show_entries", "format=duration",
+		"-of", "default=noprint_wrappers=1:nokey=1",
+		"-i", "pipe:0",
+	)
+	cmd.Stdin = file
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, errors.New("failed to read audio duration")
+	}
+
+	out := strings.TrimSpace(stdout.String())
+	if out == "" {
+		return nil, errors.New("failed to read audio duration")
+	}
+
+	durationSeconds, err := strconv.ParseFloat(out, 64)
+	if err != nil || durationSeconds <= 0 {
+		return nil, errors.New("failed to read audio duration")
+	}
+
+	seconds := max(int(math.Ceil(durationSeconds)), 1)
+	return &seconds, nil
 }
 
 func verifySongAudioChecksumFromReader(ctx context.Context, audioPath string, expected string, r io.Reader) error {

--- a/content-service/handlers/song_handler.go
+++ b/content-service/handlers/song_handler.go
@@ -488,6 +488,7 @@ func detectAudioDurationSeconds(file multipart.File, mime string) (*int, error) 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	// #nosec G204 - tmpPath is created by os.CreateTemp and not user-controlled.
 	cmd := exec.CommandContext(
 		ctx,
 		"ffprobe",

--- a/content-service/handlers/song_handler_test.go
+++ b/content-service/handlers/song_handler_test.go
@@ -2,14 +2,25 @@ package handlers
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"io"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+func withDurationDetector(t *testing.T, fn func(multipart.File, string) (*int, error)) {
+	t.Helper()
+	prev := audioDurationDetector
+	audioDurationDetector = fn
+	t.Cleanup(func() {
+		audioDurationDetector = prev
+	})
+}
 
 type multipartTestFile struct {
 	fieldName string
@@ -43,13 +54,33 @@ func buildMultipartRequest(t *testing.T, files []multipartTestFile) *http.Reques
 }
 
 func minimalWavBytes(payload []byte) []byte {
-	header := []byte{
-		'R', 'I', 'F', 'F',
-		0x24, 0x00, 0x00, 0x00,
-		'W', 'A', 'V', 'E',
-		'f', 'm', 't', ' ',
+	l := len(payload)
+	if l > math.MaxUint32-44 {
+		panic("payload too large for minimal WAV header")
 	}
-	return append(header, payload...)
+
+	dataSize := uint32(l)
+	chunkSize := uint32(36) + dataSize
+	byteRate := uint32(8000 * 2) // 8kHz * mono * 16-bit
+	blockAlign := uint16(2)
+
+	buf := make([]byte, 44+len(payload))
+	copy(buf[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(buf[4:8], chunkSize)
+	copy(buf[8:12], "WAVE")
+	copy(buf[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(buf[16:20], 16)
+	binary.LittleEndian.PutUint16(buf[20:22], 1) // PCM
+	binary.LittleEndian.PutUint16(buf[22:24], 1) // mono
+	binary.LittleEndian.PutUint32(buf[24:28], 8000)
+	binary.LittleEndian.PutUint32(buf[28:32], byteRate)
+	binary.LittleEndian.PutUint16(buf[32:34], blockAlign)
+	binary.LittleEndian.PutUint16(buf[34:36], 16)
+	copy(buf[36:40], "data")
+	binary.LittleEndian.PutUint32(buf[40:44], dataSize)
+	copy(buf[44:], payload)
+
+	return buf
 }
 
 func TestParseMultipartWithLimit_InvalidMultipart(t *testing.T) {
@@ -67,6 +98,11 @@ func TestParseMultipartWithLimit_InvalidMultipart(t *testing.T) {
 }
 
 func TestGetSingleValidatedAudioUpload_ValidAudio_ReturnsFullReader(t *testing.T) {
+	withDurationDetector(t, func(_ multipart.File, _ string) (*int, error) {
+		v := 2
+		return &v, nil
+	})
+
 	original := minimalWavBytes([]byte("track-bytes-after-header"))
 	req := buildMultipartRequest(t, []multipartTestFile{
 		{fieldName: "file", fileName: "track.wav", content: original},
@@ -77,7 +113,7 @@ func TestGetSingleValidatedAudioUpload_ValidAudio_ReturnsFullReader(t *testing.T
 		t.Fatalf("parseMultipartWithLimit failed: %v", err)
 	}
 
-	file, reader, ext, mime, ok := getSingleValidatedAudioUpload(rec, req)
+	file, reader, ext, mime, lengthSeconds, ok := getSingleValidatedAudioUpload(rec, req)
 	if !ok {
 		t.Fatalf("expected valid upload, got status=%d body=%s", rec.Code, rec.Body.String())
 	}
@@ -88,6 +124,9 @@ func TestGetSingleValidatedAudioUpload_ValidAudio_ReturnsFullReader(t *testing.T
 	}
 	if mime != "audio/wav" && mime != "audio/x-wav" {
 		t.Fatalf("expected wav mime, got %q", mime)
+	}
+	if lengthSeconds == nil || *lengthSeconds < 1 {
+		t.Fatalf("expected derived duration to be set, got %+v", lengthSeconds)
 	}
 
 	got, err := io.ReadAll(reader)
@@ -110,7 +149,7 @@ func TestGetSingleValidatedAudioUpload_RejectsMultipleFiles(t *testing.T) {
 		t.Fatalf("parseMultipartWithLimit failed: %v", err)
 	}
 
-	_, _, _, _, ok := getSingleValidatedAudioUpload(rec, req)
+	_, _, _, _, _, ok := getSingleValidatedAudioUpload(rec, req)
 	if ok {
 		t.Fatal("expected validation to fail for multiple files")
 	}
@@ -132,7 +171,7 @@ func TestGetSingleValidatedAudioUpload_RejectsMissingFileField(t *testing.T) {
 		t.Fatalf("parseMultipartWithLimit failed: %v", err)
 	}
 
-	_, _, _, _, ok := getSingleValidatedAudioUpload(rec, req)
+	_, _, _, _, _, ok := getSingleValidatedAudioUpload(rec, req)
 	if ok {
 		t.Fatal("expected validation to fail for missing 'file' field")
 	}
@@ -155,7 +194,7 @@ func TestGetSingleValidatedAudioUpload_RejectsNonAudioMime(t *testing.T) {
 		t.Fatalf("parseMultipartWithLimit failed: %v", err)
 	}
 
-	_, _, _, _, ok := getSingleValidatedAudioUpload(rec, req)
+	_, _, _, _, _, ok := getSingleValidatedAudioUpload(rec, req)
 	if ok {
 		t.Fatal("expected validation to fail for non-audio file")
 	}

--- a/content-service/mappers/song_mapper.go
+++ b/content-service/mappers/song_mapper.go
@@ -9,10 +9,9 @@ import (
 // ToSongEntity converts a SongDto to a Song entity with associated genres and artists.
 func ToSongEntity(a *dtos.SongDto, genres []entities.Genre, artists []entities.Artist) (*entities.Song, error) {
 	return &entities.Song{
-		ID:            primitive.NewObjectID(),
-		Title:         a.Title,
-		Genres:        genres,
-		LengthSeconds: a.LengthSeconds,
-		Artists:       artists,
+		ID:      primitive.NewObjectID(),
+		Title:   a.Title,
+		Genres:  genres,
+		Artists: artists,
 	}, nil
 }

--- a/content-service/repositories/song_repository.go
+++ b/content-service/repositories/song_repository.go
@@ -117,11 +117,18 @@ func (r *SongRepository) UpdateAudioByID(
 	size int64,
 	mime string,
 	checksum string,
+	lengthSeconds *int,
 ) (*entities.Song, error) {
-	return r.UpdateByID(ctx, id, map[string]any{
+	update := map[string]any{
 		"audio_path":      audioPath,
 		"audio_size":      size,
 		"audio_mime_type": mime,
 		"audio_checksum":  checksum,
-	})
+	}
+
+	if lengthSeconds != nil {
+		update["length_seconds"] = *lengthSeconds
+	}
+
+	return r.UpdateByID(ctx, id, update)
 }

--- a/content-service/repositories/song_repository_test.go
+++ b/content-service/repositories/song_repository_test.go
@@ -44,11 +44,13 @@ func TestSongRepositoryUpdateAudioByID(t *testing.T) {
 				{Key: "audio_size", Value: int64(42)},
 				{Key: "audio_mime_type", Value: "audio/mpeg"},
 				{Key: "audio_checksum", Value: "sha256-hash"},
+				{Key: "length_seconds", Value: int32(9)},
 			}},
 			bson.E{Key: "ok", Value: 1},
 		))
 
-		got, err := repo.UpdateAudioByID(context.Background(), oid, expectedPath, 42, "audio/mpeg", "sha256-hash")
+		lengthSeconds := 9
+		got, err := repo.UpdateAudioByID(context.Background(), oid, expectedPath, 42, "audio/mpeg", "sha256-hash", &lengthSeconds)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -63,6 +65,9 @@ func TestSongRepositoryUpdateAudioByID(t *testing.T) {
 		}
 		if got.AudioChecksum != "sha256-hash" {
 			t.Fatalf("expected checksum sha256-hash, got %q", got.AudioChecksum)
+		}
+		if got.LengthSeconds != lengthSeconds {
+			t.Fatalf("expected length seconds %d, got %d", lengthSeconds, got.LengthSeconds)
 		}
 	})
 }

--- a/content-service/services/song_service.go
+++ b/content-service/services/song_service.go
@@ -40,6 +40,7 @@ type songRepo interface {
 		size int64,
 		mime string,
 		checksum string,
+		lengthSeconds *int,
 	) (*entities.Song, error)
 }
 
@@ -271,9 +272,6 @@ func (s *SongService) UpdateSong(ctx context.Context, idStr string, dto dtos.Upd
 		}
 		update["genres"] = embeddedGenres
 	}
-	if dto.LengthSeconds != nil {
-		update["length_seconds"] = *dto.LengthSeconds
-	}
 	if dto.ArtistIds != nil {
 		embeddedArtists := make([]entities.Artist, 0)
 		for _, artistIdStr := range *dto.ArtistIds {
@@ -454,7 +452,7 @@ func (s *SongService) GetSongs(ctx context.Context, q SongsQuery) (*dtos.SongLis
 	}, nil
 }
 
-func (s *SongService) UploadAudio(ctx context.Context, idStr string, r io.Reader, ext string, mime string) (*entities.Song, error) {
+func (s *SongService) UploadAudio(ctx context.Context, idStr string, r io.Reader, ext string, mime string, lengthSeconds *int) (*entities.Song, error) {
 	ctx, span := s.tr.Start(ctx, "song.upload_audio")
 	defer span.End()
 
@@ -488,7 +486,7 @@ func (s *SongService) UploadAudio(ctx context.Context, idStr string, r io.Reader
 	}
 	uploadSpan.End()
 
-	updated, err := s.songRepo.UpdateAudioByID(ctx, id, audioPath, size, mime, checksum)
+	updated, err := s.songRepo.UpdateAudioByID(ctx, id, audioPath, size, mime, checksum, lengthSeconds)
 	if err != nil {
 		span.RecordError(err)
 		_ = s.hdfs.Remove(audioPath)

--- a/content-service/services/song_service_test.go
+++ b/content-service/services/song_service_test.go
@@ -17,7 +17,7 @@ import (
 
 type fakeSongRepo struct {
 	findByIDFn      func(context.Context, primitive.ObjectID) (*entities.Song, error)
-	updateAudioByID func(context.Context, primitive.ObjectID, string, int64, string, string) (*entities.Song, error)
+	updateAudioByID func(context.Context, primitive.ObjectID, string, int64, string, string, *int) (*entities.Song, error)
 	deleteByIDFn    func(context.Context, primitive.ObjectID) (*mongo.DeleteResult, error)
 
 	lastUpdateID   primitive.ObjectID
@@ -25,6 +25,7 @@ type fakeSongRepo struct {
 	lastUpdateSize int64
 	lastUpdateMime string
 	lastUpdateHash string
+	lastUpdateLen  *int
 }
 
 func (f *fakeSongRepo) Create(context.Context, entities.Song) (primitive.ObjectID, error) {
@@ -60,16 +61,22 @@ func (f *fakeSongRepo) UpdateAudioByID(
 	size int64,
 	mime string,
 	checksum string,
+	lengthSeconds *int,
 ) (*entities.Song, error) {
 	f.lastUpdateID = id
 	f.lastUpdatePath = audioPath
 	f.lastUpdateSize = size
 	f.lastUpdateMime = mime
 	f.lastUpdateHash = checksum
+	f.lastUpdateLen = lengthSeconds
 	if f.updateAudioByID != nil {
-		return f.updateAudioByID(ctx, id, audioPath, size, mime, checksum)
+		return f.updateAudioByID(ctx, id, audioPath, size, mime, checksum, lengthSeconds)
 	}
-	return &entities.Song{ID: id, AudioPath: audioPath, AudioSize: size, AudioMimeType: mime, AudioChecksum: checksum}, nil
+	song := &entities.Song{ID: id, AudioPath: audioPath, AudioSize: size, AudioMimeType: mime, AudioChecksum: checksum}
+	if lengthSeconds != nil {
+		song.LengthSeconds = *lengthSeconds
+	}
+	return song, nil
 }
 
 type fakeAlbumManager struct {
@@ -131,7 +138,7 @@ func newTestSongService(repo songRepo, album albumSongManager, hdfs audioStore) 
 func TestSongServiceUploadAudio_InvalidID(t *testing.T) {
 	svc := newTestSongService(&fakeSongRepo{}, &fakeAlbumManager{}, &fakeAudioStore{})
 
-	_, err := svc.UploadAudio(context.Background(), "bad-id", strings.NewReader("x"), ".mp3", "audio/mpeg")
+	_, err := svc.UploadAudio(context.Background(), "bad-id", strings.NewReader("x"), ".mp3", "audio/mpeg", nil)
 	if !errors.Is(err, ErrObjectIdCastFailed) {
 		t.Fatalf("expected ErrObjectIdCastFailed, got %v", err)
 	}
@@ -145,7 +152,7 @@ func TestSongServiceUploadAudio_SongNotFound(t *testing.T) {
 	}
 	svc := newTestSongService(repo, &fakeAlbumManager{}, &fakeAudioStore{})
 
-	_, err := svc.UploadAudio(context.Background(), primitive.NewObjectID().Hex(), strings.NewReader("x"), ".mp3", "audio/mpeg")
+	_, err := svc.UploadAudio(context.Background(), primitive.NewObjectID().Hex(), strings.NewReader("x"), ".mp3", "audio/mpeg", nil)
 	if !errors.Is(err, ErrSongNotFound) {
 		t.Fatalf("expected ErrSongNotFound, got %v", err)
 	}
@@ -160,14 +167,18 @@ func TestSongServiceUploadAudio_SuccessUpdatesMetadataAndRemovesOldFile(t *testi
 		findByIDFn: func(context.Context, primitive.ObjectID) (*entities.Song, error) {
 			return &entities.Song{ID: id, AudioPath: oldPath}, nil
 		},
-		updateAudioByID: func(_ context.Context, gotID primitive.ObjectID, gotPath string, gotSize int64, gotMime string, gotHash string) (*entities.Song, error) {
-			return &entities.Song{
+		updateAudioByID: func(_ context.Context, gotID primitive.ObjectID, gotPath string, gotSize int64, gotMime string, gotHash string, gotLen *int) (*entities.Song, error) {
+			song := &entities.Song{
 				ID:            gotID,
 				AudioPath:     gotPath,
 				AudioSize:     gotSize,
 				AudioMimeType: gotMime,
 				AudioChecksum: gotHash,
-			}, nil
+			}
+			if gotLen != nil {
+				song.LengthSeconds = *gotLen
+			}
+			return song, nil
 		},
 	}
 	store := &fakeAudioStore{
@@ -187,7 +198,8 @@ func TestSongServiceUploadAudio_SuccessUpdatesMetadataAndRemovesOldFile(t *testi
 	}
 	svc := newTestSongService(repo, &fakeAlbumManager{}, store)
 
-	got, err := svc.UploadAudio(context.Background(), id.Hex(), strings.NewReader("song-bytes"), ".mp3", "audio/mpeg")
+	lengthSeconds := 42
+	got, err := svc.UploadAudio(context.Background(), id.Hex(), strings.NewReader("song-bytes"), ".mp3", "audio/mpeg", &lengthSeconds)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -199,6 +211,9 @@ func TestSongServiceUploadAudio_SuccessUpdatesMetadataAndRemovesOldFile(t *testi
 	}
 	if repo.lastUpdateHash == "" {
 		t.Fatal("expected checksum to be persisted")
+	}
+	if repo.lastUpdateLen == nil || *repo.lastUpdateLen != lengthSeconds {
+		t.Fatalf("expected duration %d to be persisted, got %+v", lengthSeconds, repo.lastUpdateLen)
 	}
 	if store.removedPath != oldPath {
 		t.Fatalf("expected old path to be removed, got %s", store.removedPath)


### PR DESCRIPTION
Removes `length_seconds` from song request DTOs and derives song duration server-side from uploaded audio using `ffprobe` within `ffmpeg`.

Alteres `Dockerfile` for `content-service` that bundles `ffmpeg` on Alpine linux.