### PR TITLE
Genre/ Artist subscriber count

### DIFF
--- a/subscription-service/dtos/subscription_dto.go
+++ b/subscription-service/dtos/subscription_dto.go
@@ -11,4 +11,8 @@ type CreateSubscriptionDto struct {
 	Type     subscription.SubscriptionType `json:"sub_type" validate:"required,validsubtype"`
 }
 
+type EntitySubscriberCountDTO struct {
+	SubscriberCount int64 `json:"sub_count"`
+}
+
 type SubsListResponseDto = commondtos.ItemCollectionResponse[entities.Subscription]

--- a/subscription-service/handlers/subscription_handler.go
+++ b/subscription-service/handlers/subscription_handler.go
@@ -30,6 +30,33 @@ func NewSubscriptionHandler(s services.SubscriptionService, v validator.Validate
 	return &h
 }
 
+func (h *SubscriptionHandler) HandleIsSubscribed(w http.ResponseWriter, r *http.Request) {
+	qEntityIDstr := mux.Vars(r)["entityID"]
+
+	entityID, err := primitive.ObjectIDFromHex(qEntityIDstr)
+	if err != nil {
+		logging.Errorf(r.Context(), "an error has occured while parsing entityID: %v", err)
+		_ = respond.BadRequest(w)
+		return
+	}
+
+	err = h.s.IsSubscribed(entityID, r.Context())
+	if err != nil {
+		switch {
+		case errors.Is(err, repositories.ErrSubscriptionNotFound):
+			logging.Errorf(r.Context(), "subscription not found: %v", err)
+			_ = respond.NotFound(w)
+			return
+		default:
+			logging.Errorf(r.Context(), "failed to check if user is subscribed: %v", err)
+			_ = respond.InternalServerError(w)
+			return
+		}
+	}
+
+	_ = respond.Ok(w, "subscription exists")
+}
+
 func (h *SubscriptionHandler) HandleSubscribe(w http.ResponseWriter, r *http.Request) {
 	var req dtos.CreateSubscriptionDto
 

--- a/subscription-service/handlers/subscription_handler.go
+++ b/subscription-service/handlers/subscription_handler.go
@@ -124,5 +124,5 @@ func (h *SubscriptionHandler) HandleSubscriberCount(w http.ResponseWriter, r *ht
 		return
 	}
 
-	respond.OkJson(w, resp)
+	_ = respond.OkJson(w, resp)
 }

--- a/subscription-service/handlers/subscription_handler.go
+++ b/subscription-service/handlers/subscription_handler.go
@@ -105,3 +105,24 @@ func (h *SubscriptionHandler) HandleUserSubscriptionsList(w http.ResponseWriter,
 		return h.s.ListUserSubscriptions(ctx, query)
 	})
 }
+
+func (h *SubscriptionHandler) HandleSubscriberCount(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	entityIdStr := vars["entityID"]
+
+	entityId, err := primitive.ObjectIDFromHex(entityIdStr)
+	if err != nil {
+		logging.Errorf(r.Context(), "failed to process subscriber count request: %v", err)
+		_ = respond.BadRequest(w, respond.ErrorMessage("Invalid entity ID."))
+		return
+	}
+
+	resp, err := h.s.FindEntitySubscriberCount(r.Context(), entityId)
+	if err != nil {
+		logging.Errorf(r.Context(), "failed to process subscriber count request: %v", err)
+		_ = respond.BadRequest(w, respond.ErrorMessage("An error has occurred while fetching subscriber count."))
+		return
+	}
+
+	respond.OkJson(w, resp)
+}

--- a/subscription-service/repositories/subscription_repository.go
+++ b/subscription-service/repositories/subscription_repository.go
@@ -17,6 +17,7 @@ var (
 	ErrFindSubscriptions         = errors.New("error has occured while finding subscriptions for the given parameters")
 	ErrSubscriptionCursor        = errors.New("error has occured while loading subscription cursor")
 	ErrUUIDParse                 = errors.New("error has occurred while parsing target IDs")
+	ErrSubscriptionNotFound      = errors.New("subscription not found")
 )
 
 type SubscriptionRepository struct {
@@ -33,6 +34,23 @@ func NewSubscriptionRepository(dbName string, collName string, c *mongo.Client) 
 	r := SubscriptionRepository{Client: c, DbName: dbName, CollName: collName}
 
 	return &r
+}
+
+func (r *SubscriptionRepository) IsSubscribed(subscriberID, entityID primitive.ObjectID, ctx context.Context) error {
+	c := r.getCollection()
+
+	filter := bson.M{"subscriber_id": subscriberID, "entity_id": entityID}
+	err := c.FindOne(ctx, filter).Err()
+	if err != nil {
+		switch {
+		case errors.Is(err, mongo.ErrNoDocuments):
+			return ErrSubscriptionNotFound
+		default:
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (r *SubscriptionRepository) Create(s *entities.Subscription, ctx context.Context) error {

--- a/subscription-service/repositories/subscription_repository.go
+++ b/subscription-service/repositories/subscription_repository.go
@@ -142,3 +142,18 @@ func (r *SubscriptionRepository) FindSubscriptionsByUserID(ctx context.Context, 
 
 	return subscriptions, tc, nil
 }
+
+func (r *SubscriptionRepository) FindEntitySubscriberCount(ctx context.Context, entityID primitive.ObjectID) (int64, error) {
+	c := r.getCollection()
+
+	filter := bson.M{
+		"entity_id": entityID,
+	}
+
+	count, err := c.CountDocuments(ctx, filter)
+	if err != nil {
+		return 0, err
+	}
+
+	return count, nil
+}

--- a/subscription-service/routers/router.go
+++ b/subscription-service/routers/router.go
@@ -17,6 +17,7 @@ func HandleRequests(sh *handlers.SubscriptionHandler) http.Handler {
 	telemetry.AttachMuxTracing(api, "subscription-service")
 
 	api.Handle("/", middlewares.RequireAuthenticated(sh.HandleSubscribe)).Methods("POST")
+	api.Handle("/count/{entityID}", middlewares.RequireAuthenticated(sh.HandleSubscriberCount)).Methods("GET")
 	api.Handle("/{entityID}", middlewares.RequireAuthenticated(sh.HandleUnsubscribe)).Methods("DELETE")
 	api.Handle("/", middlewares.RequireAuthenticated(sh.HandleUserSubscriptionsList)).Methods("GET")
 

--- a/subscription-service/routers/router.go
+++ b/subscription-service/routers/router.go
@@ -16,6 +16,7 @@ func HandleRequests(sh *handlers.SubscriptionHandler) http.Handler {
 	api := r.PathPrefix("/").Subrouter()
 	telemetry.AttachMuxTracing(api, "subscription-service")
 
+	api.Handle("/{entityID}", middlewares.RequireAuthenticated(sh.HandleIsSubscribed)).Methods("GET")
 	api.Handle("/", middlewares.RequireAuthenticated(sh.HandleSubscribe)).Methods("POST")
 	api.Handle("/count/{entityID}", middlewares.RequireAuthenticated(sh.HandleSubscriberCount)).Methods("GET")
 	api.Handle("/{entityID}", middlewares.RequireAuthenticated(sh.HandleUnsubscribe)).Methods("DELETE")

--- a/subscription-service/services/subscription_service.go
+++ b/subscription-service/services/subscription_service.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	ErrEntityNotFound       = errors.New("genre/artist couldn't be found")
-	ErrSubscriptionNotFound = errors.New("subscription not found")
+	ErrSubscriptionNotFound = errors.New("subscription couldn't found")
 	ErrInvalidEntityID      = errors.New("error has ocurred while parsing genre/artist id")
 	ErrUpstreamFailure      = errors.New("error has ocurred while fetching artist/genre")
 	ErrPublish              = errors.New("error has occured while publishing subscriber batch event")
@@ -38,6 +38,7 @@ type SubscriptionRepository interface {
 	Create(s *entities.Subscription, ctx context.Context) error
 	Delete(entityID primitive.ObjectID, userID primitive.ObjectID, ctx context.Context) (int64, error)
 	FindSubscriptionsByEntityID(ctx context.Context, targetIDStrs []string, batchSize int, lastID string) ([]*entities.Subscription, string, error)
+	IsSubscribed(subscriberID, entityID primitive.ObjectID, ctx context.Context) error
 	FindSubscriptionsByUserID(ctx context.Context, filter bson.M, skip int64, limit int64) ([]entities.Subscription, int64, error)
 	FindEntitySubscriberCount(ctx context.Context, entityID primitive.ObjectID) (int64, error)
 }
@@ -58,6 +59,27 @@ func NewSubscriptionService(sr SubscriptionRepository, gcc ContentEntityGetter, 
 	s := SubscriptionService{sr: sr, gcc: gcc, jsc: jsc, tr: tr}
 
 	return &s
+}
+
+func (s *SubscriptionService) IsSubscribed(entityID primitive.ObjectID, ctx context.Context) error {
+	existsCtx, existsSpan := s.tr.Start(ctx, "subscription.exists")
+	defer existsSpan.End()
+
+	userIDstr := middlewares.GetUserIdFromContext(ctx)
+
+	subscriberID, err := primitive.ObjectIDFromHex(userIDstr)
+	if err != nil {
+		existsSpan.RecordError(err)
+		return err
+	}
+
+	err = s.sr.IsSubscribed(subscriberID, entityID, existsCtx)
+	if err != nil {
+		existsSpan.RecordError(err)
+		return err
+	}
+
+	return nil
 }
 
 func (s *SubscriptionService) Subscribe(req *dtos.CreateSubscriptionDto, ctx context.Context) error {

--- a/subscription-service/services/subscription_service.go
+++ b/subscription-service/services/subscription_service.go
@@ -39,6 +39,7 @@ type SubscriptionRepository interface {
 	Delete(entityID primitive.ObjectID, userID primitive.ObjectID, ctx context.Context) (int64, error)
 	FindSubscriptionsByEntityID(ctx context.Context, targetIDStrs []string, batchSize int, lastID string) ([]*entities.Subscription, string, error)
 	FindSubscriptionsByUserID(ctx context.Context, filter bson.M, skip int64, limit int64) ([]entities.Subscription, int64, error)
+	FindEntitySubscriberCount(ctx context.Context, entityID primitive.ObjectID) (int64, error)
 }
 
 type ContentEntityGetter interface {
@@ -212,4 +213,17 @@ func (s *SubscriptionService) ListUserSubscriptions(ctx context.Context, q SubsQ
 	p := pagination.NewPagination(q.Page, q.Size)
 
 	return commondtos.ListWithPagination(findCtx, p, filter, s.sr.FindSubscriptionsByUserID)
+}
+
+func (s *SubscriptionService) FindEntitySubscriberCount(ctx context.Context, entityID primitive.ObjectID) (*dtos.EntitySubscriberCountDTO, error) {
+	countCtx, countSpan := s.tr.Start(ctx, "subscription.count")
+	defer countSpan.End()
+
+	c, err := s.sr.FindEntitySubscriberCount(countCtx, entityID)
+	if err != nil {
+		countSpan.RecordError(err)
+		return nil, err
+	}
+
+	return &dtos.EntitySubscriberCountDTO{SubscriberCount: c}, nil
 }

--- a/subscription-service/services/subscription_service_test.go
+++ b/subscription-service/services/subscription_service_test.go
@@ -32,6 +32,7 @@ type fakeSubscriptionRepo struct {
 	deleteEntity    primitive.ObjectID
 	subscriptionIDs []string
 	lastID          string
+	dataSubCount    map[primitive.ObjectID][]primitive.ObjectID
 	batchSize       int
 	store           []entities.Subscription
 }
@@ -100,7 +101,18 @@ func (f *fakeSubscriptionRepo) Delete(
 }
 
 func (f *fakeSubscriptionRepo) FindEntitySubscriberCount(ctx context.Context, entityID primitive.ObjectID) (int64, error) {
-	return 0, errors.New("")
+	var count int64 = 0
+
+	for _, subscribedEntities := range f.dataSubCount {
+		for _, id := range subscribedEntities {
+			if id == entityID {
+				count++
+				break // Found it for this user, stop checking this user's list (prevent double counting)
+			}
+		}
+	}
+
+	return count, nil
 }
 
 type fakeContentGetter struct {
@@ -227,6 +239,103 @@ func TestFakeSubscriptionRepo_FindSubscriptionsByUserID(t *testing.T) {
 	}
 }
 
+func TestFakeSubscriptionRepo_FindEntitySubscriberCount(t *testing.T) {
+	// Generate IDs for use in tests
+	userA := primitive.NewObjectID()
+	userB := primitive.NewObjectID()
+	userC := primitive.NewObjectID()
+
+	targetEntity := primitive.NewObjectID()
+	otherEntity := primitive.NewObjectID()
+
+	tests := []struct {
+		name          string
+		setup         func(*fakeSubscriptionRepo)
+		queryEntityID primitive.ObjectID
+		expectedCount int64
+		expectError   bool
+	}{
+		{
+			name: "Zero count: Repo is empty",
+			setup: func(f *fakeSubscriptionRepo) {
+				// No data
+			},
+			queryEntityID: targetEntity,
+			expectedCount: 0,
+			expectError:   false,
+		},
+		{
+			name: "Count 1: One user subscribed to target",
+			setup: func(f *fakeSubscriptionRepo) {
+				f.AddSubscription(userA, targetEntity)
+			},
+			queryEntityID: targetEntity,
+			expectedCount: 1,
+			expectError:   false,
+		},
+		{
+			name: "Count 2: Two users subscribed to target",
+			setup: func(f *fakeSubscriptionRepo) {
+				f.AddSubscription(userA, targetEntity)
+				f.AddSubscription(userB, targetEntity)
+			},
+			queryEntityID: targetEntity,
+			expectedCount: 2,
+			expectError:   false,
+		},
+		{
+			name: "Mixed Data: Users subscribed to different entities",
+			setup: func(f *fakeSubscriptionRepo) {
+				f.AddSubscription(userA, targetEntity) // Should count
+				f.AddSubscription(userB, otherEntity)  // Should NOT count
+				f.AddSubscription(userC, targetEntity) // Should count
+			},
+			queryEntityID: targetEntity,
+			expectedCount: 2,
+			expectError:   false,
+		},
+		{
+			name: "Zero count: Users exist but subscribed to other entities",
+			setup: func(f *fakeSubscriptionRepo) {
+				f.AddSubscription(userA, otherEntity)
+			},
+			queryEntityID: targetEntity,
+			expectedCount: 0,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 1. Initialize Repo
+			repo := &fakeSubscriptionRepo{}
+
+			// 2. Setup Data
+			if tt.setup != nil {
+				tt.setup(repo)
+			}
+
+			// 3. Execute
+			count, err := repo.FindEntitySubscriberCount(context.Background(), tt.queryEntityID)
+
+			// 4. Verify Error
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// 5. Verify Count
+			if count != tt.expectedCount {
+				t.Errorf("expected count %d, got %d", tt.expectedCount, count)
+			}
+		})
+	}
+}
+
 func TestSubscribeSuccess(t *testing.T) {
 	repo := &fakeSubscriptionRepo{}
 	getter := &fakeContentGetter{
@@ -290,6 +399,13 @@ func TestSubscribeInvalidEntityID(t *testing.T) {
 
 	require.ErrorIs(t, err, ErrInvalidEntityID)
 	require.False(t, repo.createCalled)
+}
+
+func (f *fakeSubscriptionRepo) AddSubscription(subID, entID primitive.ObjectID) {
+	if f.dataSubCount == nil {
+		f.dataSubCount = make(map[primitive.ObjectID][]primitive.ObjectID)
+	}
+	f.dataSubCount[subID] = append(f.dataSubCount[subID], entID)
 }
 
 func TestSubscribeUpstreamFailure(t *testing.T) {

--- a/subscription-service/services/subscription_service_test.go
+++ b/subscription-service/services/subscription_service_test.go
@@ -99,6 +99,10 @@ func (f *fakeSubscriptionRepo) Delete(
 	return 1, nil
 }
 
+func (f *fakeSubscriptionRepo) FindEntitySubscriberCount(ctx context.Context, entityID primitive.ObjectID) (int64, error) {
+	return 0, errors.New("")
+}
+
 type fakeContentGetter struct {
 	getEntityFn func(context.Context, string, subscription.SubscriptionType) (string, error)
 	lastType    subscription.SubscriptionType

--- a/subscription-service/services/subscription_service_test.go
+++ b/subscription-service/services/subscription_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,6 +21,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var ErrNotSubscribed = errors.New("subscription not found")
+
 //nolint:unused
 type fakeSubscriptionRepo struct {
 	createFn func(*entities.Subscription, context.Context) error
@@ -35,6 +38,7 @@ type fakeSubscriptionRepo struct {
 	dataSubCount    map[primitive.ObjectID][]primitive.ObjectID
 	batchSize       int
 	store           []entities.Subscription
+	data            map[primitive.ObjectID][]primitive.ObjectID
 }
 
 // FindSubscriptionsByEntityID implements [SubscriptionRepository].
@@ -53,7 +57,6 @@ func (f *fakeSubscriptionRepo) FindSubscriptionsByUserID(ctx context.Context, fi
 		return []entities.Subscription{}, 0, nil
 	}
 
-	// 2. Filter data
 	var filtered []entities.Subscription
 	for _, sub := range f.store {
 		if sub.SubscriberID == targetUserID {
@@ -63,13 +66,11 @@ func (f *fakeSubscriptionRepo) FindSubscriptionsByUserID(ctx context.Context, fi
 
 	totalCount := int64(len(filtered))
 
-	// 3. Apply Skip
 	if skip > int64(len(filtered)) {
 		return []entities.Subscription{}, totalCount, nil
 	}
 	filtered = filtered[skip:]
 
-	// 4. Apply Limit
 	if limit > 0 && int64(len(filtered)) > limit {
 		filtered = filtered[:limit]
 	}
@@ -136,6 +137,26 @@ func (f *fakeContentGetter) GetEntity(
 
 func contextWithUserID(ctx context.Context, id primitive.ObjectID) context.Context {
 	return middlewares.ContextWithUserID(ctx, id.Hex())
+}
+
+func (f *fakeSubscriptionRepo) AddSubscription(subID, entID primitive.ObjectID) {
+	if f.data == nil {
+		f.data = make(map[primitive.ObjectID][]primitive.ObjectID)
+	}
+	f.data[subID] = append(f.data[subID], entID)
+}
+
+func (f *fakeSubscriptionRepo) IsSubscribed(subscriberID, entityID primitive.ObjectID, ctx context.Context) error {
+	subscriptions, ok := f.data[subscriberID]
+	if !ok {
+		return ErrNotSubscribed
+	}
+
+	if slices.Contains(subscriptions, entityID) {
+		return nil
+	}
+
+	return ErrNotSubscribed
 }
 
 func TestFakeSubscriptionRepo_FindSubscriptionsByUserID(t *testing.T) {
@@ -239,6 +260,70 @@ func TestFakeSubscriptionRepo_FindSubscriptionsByUserID(t *testing.T) {
 	}
 }
 
+func TestFakeSubscriptionRepo_IsSubscribed(t *testing.T) {
+	userA := primitive.NewObjectID()
+	userB := primitive.NewObjectID()
+	entityID1 := primitive.NewObjectID()
+	entityID2 := primitive.NewObjectID()
+
+	tests := []struct {
+		name         string
+		setup        func(*fakeSubscriptionRepo)
+		subscriberID primitive.ObjectID
+		entityID     primitive.ObjectID
+		expectError  bool
+	}{
+		{
+			name: "Success: User is subscribed",
+			setup: func(f *fakeSubscriptionRepo) {
+				f.AddSubscription(userA, entityID1)
+			},
+			subscriberID: userA,
+			entityID:     entityID1,
+			expectError:  false,
+		},
+		{
+			name: "Failure: User exists but subscribed to different entity",
+			setup: func(f *fakeSubscriptionRepo) {
+				f.AddSubscription(userA, entityID1)
+			},
+			subscriberID: userA,
+			entityID:     entityID2,
+			expectError:  true,
+		},
+		{
+			name: "Failure: User has no subscriptions",
+			setup: func(f *fakeSubscriptionRepo) {
+			},
+			subscriberID: userB,
+			entityID:     entityID1,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &fakeSubscriptionRepo{}
+
+			if tt.setup != nil {
+				tt.setup(repo)
+			}
+
+			err := repo.IsSubscribed(tt.subscriberID, tt.entityID, context.Background())
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("expected an error, but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected nil, but got error: %v", err)
+				}
+			}
+		})
+	}
+}
+
 func TestFakeSubscriptionRepo_FindEntitySubscriberCount(t *testing.T) {
 	// Generate IDs for use in tests
 	userA := primitive.NewObjectID()
@@ -267,7 +352,7 @@ func TestFakeSubscriptionRepo_FindEntitySubscriberCount(t *testing.T) {
 		{
 			name: "Count 1: One user subscribed to target",
 			setup: func(f *fakeSubscriptionRepo) {
-				f.AddSubscription(userA, targetEntity)
+				f.AddSubscriptionSC(userA, targetEntity)
 			},
 			queryEntityID: targetEntity,
 			expectedCount: 1,
@@ -276,8 +361,8 @@ func TestFakeSubscriptionRepo_FindEntitySubscriberCount(t *testing.T) {
 		{
 			name: "Count 2: Two users subscribed to target",
 			setup: func(f *fakeSubscriptionRepo) {
-				f.AddSubscription(userA, targetEntity)
-				f.AddSubscription(userB, targetEntity)
+				f.AddSubscriptionSC(userA, targetEntity)
+				f.AddSubscriptionSC(userB, targetEntity)
 			},
 			queryEntityID: targetEntity,
 			expectedCount: 2,
@@ -286,9 +371,9 @@ func TestFakeSubscriptionRepo_FindEntitySubscriberCount(t *testing.T) {
 		{
 			name: "Mixed Data: Users subscribed to different entities",
 			setup: func(f *fakeSubscriptionRepo) {
-				f.AddSubscription(userA, targetEntity) // Should count
-				f.AddSubscription(userB, otherEntity)  // Should NOT count
-				f.AddSubscription(userC, targetEntity) // Should count
+				f.AddSubscriptionSC(userA, targetEntity) // Should count
+				f.AddSubscriptionSC(userB, otherEntity)  // Should NOT count
+				f.AddSubscriptionSC(userC, targetEntity) // Should count
 			},
 			queryEntityID: targetEntity,
 			expectedCount: 2,
@@ -297,7 +382,7 @@ func TestFakeSubscriptionRepo_FindEntitySubscriberCount(t *testing.T) {
 		{
 			name: "Zero count: Users exist but subscribed to other entities",
 			setup: func(f *fakeSubscriptionRepo) {
-				f.AddSubscription(userA, otherEntity)
+				f.AddSubscriptionSC(userA, otherEntity)
 			},
 			queryEntityID: targetEntity,
 			expectedCount: 0,
@@ -401,7 +486,7 @@ func TestSubscribeInvalidEntityID(t *testing.T) {
 	require.False(t, repo.createCalled)
 }
 
-func (f *fakeSubscriptionRepo) AddSubscription(subID, entID primitive.ObjectID) {
+func (f *fakeSubscriptionRepo) AddSubscriptionSC(subID, entID primitive.ObjectID) {
 	if f.dataSubCount == nil {
 		f.dataSubCount = make(map[primitive.ObjectID][]primitive.ObjectID)
 	}

--- a/user-service/services/user_service.go
+++ b/user-service/services/user_service.go
@@ -24,6 +24,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+var hmacSampleSecret = []byte(utils.MustGetEnv("APP_JWT_SECRET"))
+
 var (
 	ErrUsernameTaken             = errors.New("username is already taken")
 	ErrEmailTaken                = errors.New("email is already taken")

--- a/user-service/services/user_service.go
+++ b/user-service/services/user_service.go
@@ -24,8 +24,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-var hmacSampleSecret = []byte(utils.MustGetEnv("APP_JWT_SECRET"))
-
 var (
 	ErrUsernameTaken             = errors.New("username is already taken")
 	ErrEmailTaken                = errors.New("email is already taken")


### PR DESCRIPTION
Adds entity subscriber count endpoint, so we can display genre/artist subscriber count on the page, isn't necessary but seems like a cool feature.

Currently the API call doesn't make a distinction when an entity doesn't exist or no one is subscribed to it, if get enough time, a check by calling the content service via gRPC will be implemented.