### PR TITLE
Ensure notification-cassandra service follows same naming

### DIFF
--- a/notification-service/README.md
+++ b/notification-service/README.md
@@ -11,7 +11,7 @@ A microservice which main goal is to persist notifications and notify users abou
 
 Additional services are available for local development:
 
-- Position yourself in the root directory run `docker compose up --build`, and then run `docker exec -it notification-cassandra cqlsh`.
+- Position yourself in the root directory run `docker compose up --build`, and then run `docker compose exec notification-cassandra cqlsh`.
   Congrats you can now run cql commands.
 
 ## Structure

--- a/notification-service/docker-compose.yml
+++ b/notification-service/docker-compose.yml
@@ -46,7 +46,6 @@ services:
   # notification cassandra service
   notification-cassandra:
     image: cassandra:${CASSANDRA_VERSION}
-    container_name: notification-cassandra
     volumes:
       - "notification-cassandra-data:/var/lib/cassandra"
     # the environments are optional and come in handy only when working with multiple nodes


### PR DESCRIPTION
All containers use Docker Compose generated names. This PR applies the same on `notification-cassandra` service.