### PR TITLE
Add User Activity Events

### DIFF
--- a/common-lib/events/entities.go
+++ b/common-lib/events/entities.go
@@ -47,15 +47,16 @@ const (
 
 	SUBJECT_RATING_CREATED = "rating.created"
 	SUBJECT_RATING_UPDATED = "rating.updated"
-	SUBJECT_RATING_DELETED = "rating.deleted"
-	RATING_DURABLE         = "RATING_PROCESSOR"
+	RATING_CREATED_DURABLE = "RATING_CREATED_PROCESSOR"
+	RATING_UPDATED_DURABLE = "RATING_UPDATED_PROCESSOR"
 
 	SUBJECT_LISTEN_CREATED = "listen.created"
 	LISTEN_DURABLE         = "LISTEN_PROCESSOR"
 
 	SUBJECT_SUBSCRIPTION_CREATED = "subscription.created"
 	SUBJECT_SUBSCRIPTION_DELETED = "subscription.deleted"
-	SUBSCRIPTION_DURABLE         = "SUBSCRIPTION_PROCESSOR"
+	SUBSCRIPTION_CREATED_DURABLE = "SUBSCRIPTION_CREATED_PROCESSOR"
+	SUBSCRIPTION_DELETED_DURABLE = "SUBSCRIPTION_DELETED_PROCESSOR"
 )
 
 type SubscriptionEntityType string
@@ -128,6 +129,7 @@ type SongUpdatePayload struct {
 type RatingEventPayload struct {
 	UserID    string    `json:"user_id"`
 	SongID    string    `json:"song_id"`
+	SongTitle string    `json:"song_title"`
 	Rating    int       `json:"rating"`
 	EventID   string    `json:"event_id"`
 	CreatedAt time.Time `json:"created_at"`
@@ -136,6 +138,7 @@ type RatingEventPayload struct {
 type ListenEventPayload struct {
 	UserID    string    `json:"user_id"`
 	SongID    string    `json:"song_id"`
+	SongTitle string    `json:"song_title"`
 	EventID   string    `json:"event_id"`
 	CreatedAt time.Time `json:"created_at"`
 }
@@ -143,6 +146,7 @@ type ListenEventPayload struct {
 type SubscriptionEventPayload struct {
 	UserID     string                 `json:"user_id"`
 	EntityID   string                 `json:"entity_id"`
+	EntityName string                 `json:"entity_name"`
 	EntityType SubscriptionEntityType `json:"entity_type"`
 	EventID    string                 `json:"event_id"`
 	CreatedAt  time.Time              `json:"created_at"`

--- a/content-service/handlers/song_handler.go
+++ b/content-service/handlers/song_handler.go
@@ -295,7 +295,8 @@ func (h *SongHandler) HandleStreamSongAudio(w http.ResponseWriter, r *http.Reque
 	id := mux.Vars(r)["id"]
 	cacheKey := "audio:" + id
 
-	if !h.authorizeAudioStreamRequest(r, id) {
+	userID, authorized := h.authorizeAudioStreamRequest(r, id)
+	if !authorized {
 		_ = respond.Unauthorized(w)
 		return
 	}
@@ -326,7 +327,9 @@ func (h *SongHandler) HandleStreamSongAudio(w http.ResponseWriter, r *http.Reque
 	if err == nil && len(cachedAudio) > 0 {
 		logging.Infof(r.Context(), "Cache HIT song: %s", id)
 		setSongAudioResponseHeaders(w, int64(len(cachedAudio)), song.AudioMimeType)
-		_, _ = w.Write(cachedAudio)
+		if _, writeErr := w.Write(cachedAudio); writeErr == nil {
+			h.s.PublishListenEvent(r.Context(), userID, song)
+		}
 		return
 	}
 
@@ -372,7 +375,9 @@ func (h *SongHandler) HandleStreamSongAudio(w http.ResponseWriter, r *http.Reque
 
 	setSongAudioResponseHeaders(w, int64(len(audioBytes)), song.AudioMimeType)
 
-	_, _ = w.Write(audioBytes)
+	if _, writeErr := w.Write(audioBytes); writeErr == nil {
+		h.s.PublishListenEvent(r.Context(), userID, song)
+	}
 }
 
 func (h *SongHandler) HandleGetSongAudioSignedURL(w http.ResponseWriter, r *http.Request) {
@@ -687,35 +692,53 @@ func verifySongAudioChecksumFromReader(ctx context.Context, audioPath string, ex
 	return fmt.Errorf("checksum mismatch path=%s", audioPath)
 }
 
-func (h *SongHandler) authorizeAudioStreamRequest(r *http.Request, songID string) bool {
+func (h *SongHandler) authorizeAudioStreamRequest(r *http.Request, songID string) (string, bool) {
 	if streamToken := strings.TrimSpace(r.URL.Query().Get("st")); streamToken != "" {
-		if validateSongStreamToken(streamToken, songID) {
-			return true
+		if userID, ok := validateSongStreamToken(streamToken, songID); ok {
+			return userID, true
 		}
 	}
 
 	accessToken := middlewares.ExtractBearerToken(r.Header.Get("Authorization"))
 	if accessToken == "" {
-		return false
+		return "", false
 	}
 
-	_, err := middlewares.ValidateJWTToken(accessToken)
-	return err == nil
+	claims, err := middlewares.ValidateJWTToken(accessToken)
+	if err != nil {
+		return "", false
+	}
+
+	userID, _ := claims["sub"].(string)
+	if userID == "" {
+		return "", false
+	}
+
+	return userID, true
 }
 
-func validateSongStreamToken(tokenStr, songID string) bool {
+func validateSongStreamToken(tokenStr, songID string) (string, bool) {
 	claims, err := middlewares.ValidateJWTToken(tokenStr)
 	if err != nil {
-		return false
+		return "", false
 	}
 
 	tokenSongID, _ := claims["song_id"].(string)
 	if tokenSongID == "" || tokenSongID != songID {
-		return false
+		return "", false
 	}
 
 	aud, _ := claims["aud"].(string)
-	return aud == "song-stream"
+	if aud != "song-stream" {
+		return "", false
+	}
+
+	userID, _ := claims["sub"].(string)
+	if userID == "" {
+		return "", false
+	}
+
+	return userID, true
 }
 
 func setSongAudioResponseHeaders(w http.ResponseWriter, size int64, mime string) {

--- a/content-service/main.go
+++ b/content-service/main.go
@@ -113,6 +113,15 @@ var (
 				return h, shutdown, err
 			}
 
+			if err = jsc.EnsureStream(
+				ctx,
+				events.LISTENS_STREAM,
+				[]string{events.SUBJECT_LISTEN_CREATED},
+			); err != nil {
+				err = fmt.Errorf("failed to ensure listens stream: %w", err)
+				return h, shutdown, err
+			}
+
 			ar, sr, alr, gr := createRepositories(dbc)
 			gs, as, ss, als, glss := createServices(ar, sr, alr, gr, jsc, hdfsStore)
 			ratingClient, ratingConn, err := infragrpc.NewRatingSummaryClient()

--- a/content-service/services/artist_service.go
+++ b/content-service/services/artist_service.go
@@ -374,7 +374,7 @@ func (s *ArtistService) syncEmbeddedAlbums(ctx context.Context, artist *entities
 	return nil
 }
 
-// syncEmbedded syncs embedded
+// syncEmbedded syncs embedded.
 func (s *ArtistService) syncEmbedded(ctx context.Context, artist *entities.Artist) error {
 	if err := s.syncEmbeddedArtists(ctx, artist); err != nil {
 		return err

--- a/content-service/services/song_service.go
+++ b/content-service/services/song_service.go
@@ -235,6 +235,32 @@ func (s *SongService) FindSongById(ctx context.Context, idStr string) (*entities
 	return song, nil
 }
 
+func (s *SongService) PublishListenEvent(ctx context.Context, userID string, song *entities.Song) {
+	if s.jsc == nil || song == nil {
+		return
+	}
+
+	payload := events.ListenEventPayload{
+		UserID:    userID,
+		SongID:    song.ID.Hex(),
+		SongTitle: song.Title,
+		EventID:   primitive.NewObjectID().Hex(),
+		CreatedAt: time.Now().UTC(),
+	}
+
+	if err := retry.Do(
+		func() error {
+			return s.jsc.Publish(ctx, events.SUBJECT_LISTEN_CREATED, payload)
+		},
+		retry.Attempts(3),
+		retry.Delay(time.Second),
+		retry.DelayType(retry.BackOffDelay),
+		retry.Context(ctx),
+	); err != nil {
+		logging.Errorf(ctx, "failed to publish listen event: %v", err)
+	}
+}
+
 // UpdateSong updates an existing song with the provided partial data.
 func (s *SongService) UpdateSong(ctx context.Context, idStr string, dto dtos.UpdateSongDto) (*entities.Song, error) {
 	updateCtx, updateSpan := s.tr.Start(ctx, "song.update_song")

--- a/frontend/src/app/services/user-activity.service.ts
+++ b/frontend/src/app/services/user-activity.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export type ActivityType =
+  | 'LISTEN'
+  | 'SUBSCRIPTION_CREATED'
+  | 'SUBSCRIPTION_DELETED'
+  | 'RATING_CREATED'
+  | 'RATING_UPDATED';
+
+export interface UserActivity {
+  event_id: string;
+  user_id: string;
+  type: ActivityType;
+  entity_id?: string;
+  entity_name?: string;
+  entity_type?: string;
+  rating_value?: number;
+  occurred_at: string;
+  created_at: string;
+}
+
+export interface UserActivityResponse {
+  items: UserActivity[];
+  total: number;
+  page: number;
+  size: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class UserActivityService {
+  private readonly http = inject(HttpClient);
+  private readonly apiBase = `${environment.apiBaseUrl}/users`;
+
+  getMyActivities(page: number = 1, size: number = 20): Observable<UserActivityResponse> {
+    return this.http.get<UserActivityResponse>(`${this.apiBase}/activities`, {
+      params: { page, size },
+    });
+  }
+}

--- a/frontend/src/app/shared/components/header/components/user-profile-dropdown/user-profile-dropdown.html
+++ b/frontend/src/app/shared/components/header/components/user-profile-dropdown/user-profile-dropdown.html
@@ -78,6 +78,58 @@
     }
   </div>
 
+  <div class="user-profile__activity">
+    <button
+      class="user-profile__nav-button"
+      [class.user-profile__nav-button--active]="activityMenuOpenSg()"
+      (click)="toggleActivityMenu()"
+      type="button"
+      aria-label="Activity history"
+      title="Activity history"
+    >
+      <mat-icon aria-hidden="true">history</mat-icon>
+    </button>
+
+    @if (activityMenuOpenSg()) {
+      <div class="user-profile__menu">
+        <div class="user-profile__menu-header">
+          <strong>Activity history</strong>
+        </div>
+
+        <div class="user-profile__menu-list" (scroll)="onActivityListScroll($event)">
+          @if (activityLoadingSg()) {
+            <p class="user-profile__empty">Loading...</p>
+          } @else if (activitiesSg().length === 0) {
+            <p class="user-profile__empty">No activity yet.</p>
+          } @else {
+            @for (item of activitiesSg(); track trackActivity($index, item)) {
+              <button type="button" class="user-profile__item" (click)="openActivity(item)">
+                <span class="user-profile__item-main">
+                  <span class="user-profile__item-title">{{ activityTitle(item) }}</span>
+                  @if (item.type === 'RATING_CREATED' || item.type === 'RATING_UPDATED') {
+                    <span class="user-profile__item-message user-profile__item-message--rating">
+                      <span>Rated song</span>
+                      <mat-icon aria-hidden="true">star</mat-icon>
+                      <span>{{ item.rating_value ?? 0 }}</span>
+                    </span>
+                  } @else {
+                    <span class="user-profile__item-message">{{ activityDescription(item) }}</span>
+                  }
+                </span>
+                <span class="user-profile__item-side">
+                  <span class="user-profile__item-time">{{ activityWhen(item) }}</span>
+                </span>
+              </button>
+            }
+            @if (activityLoadingMoreSg()) {
+              <p class="user-profile__empty">Loading more...</p>
+            }
+          }
+        </div>
+      </div>
+    }
+  </div>
+
   @if (authService.isAdminSg()) {
     <button
       class="user-profile__nav-button"

--- a/frontend/src/app/shared/components/header/components/user-profile-dropdown/user-profile-dropdown.scss
+++ b/frontend/src/app/shared/components/header/components/user-profile-dropdown/user-profile-dropdown.scss
@@ -11,6 +11,10 @@
     position: relative;
   }
 
+  &__activity {
+    position: relative;
+  }
+
   &__nav-button {
     position: relative;
     display: inline-flex;
@@ -220,6 +224,19 @@
     overflow: hidden;
     text-overflow: ellipsis;
     max-width: 260px;
+
+    &--rating {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+
+      mat-icon {
+        width: 13px;
+        height: 13px;
+        font-size: 13px;
+        color: #fbbf24;
+      }
+    }
   }
 
   &__item-side {

--- a/frontend/src/app/shared/components/header/components/user-profile-dropdown/user-profile-dropdown.ts
+++ b/frontend/src/app/shared/components/header/components/user-profile-dropdown/user-profile-dropdown.ts
@@ -240,11 +240,7 @@ export class UserProfileDropdownComponent implements OnDestroy {
       return;
     }
 
-    if (
-      !this.hasMoreActivitiesSg() ||
-      this.activityLoadingSg() ||
-      this.activityLoadingMoreSg()
-    ) {
+    if (!this.hasMoreActivitiesSg() || this.activityLoadingSg() || this.activityLoadingMoreSg()) {
       return;
     }
 
@@ -455,7 +451,9 @@ export class UserProfileDropdownComponent implements OnDestroy {
       while (true) {
         const response = await firstValueFrom(this.albumService.getAlbums(page, size));
         const albums = response.items ?? [];
-        const matched = albums.find((album) => (album.songs ?? []).some((song) => song.id === songId));
+        const matched = albums.find((album) =>
+          (album.songs ?? []).some((song) => song.id === songId)
+        );
         if (matched) {
           this.songAlbumCache.set(songId, matched.id);
           this.router.navigate(['/album', matched.id]);

--- a/frontend/src/app/shared/components/header/components/user-profile-dropdown/user-profile-dropdown.ts
+++ b/frontend/src/app/shared/components/header/components/user-profile-dropdown/user-profile-dropdown.ts
@@ -13,10 +13,13 @@ import { Router } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AuthService } from '@app/services/auth.service';
+import { AlbumService } from '@app/services/album.service';
 import { Notification, NotificationService } from '@app/services/notification.service';
+import { UserActivity, UserActivityService } from '@app/services/user-activity.service';
 import { CoverArtComponent } from '@app/shared/components/cover-art/cover-art';
 import { ProfileEditorDialogComponent } from '@app/dialogs/profile-editor-dialog/profile-editor-dialog';
 import { ChangePasswordDialogComponent } from '@app/dialogs/change-password-dialog/change-password-dialog';
+import { firstValueFrom } from 'rxjs';
 
 type NotificationFilter = 'all' | 'artists' | 'albums';
 
@@ -36,6 +39,8 @@ type NotificationFilter = 'all' | 'artists' | 'albums';
 export class UserProfileDropdownComponent implements OnDestroy {
   readonly authService = inject(AuthService);
   readonly notificationService = inject(NotificationService);
+  readonly userActivityService = inject(UserActivityService);
+  readonly albumService = inject(AlbumService);
 
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
@@ -43,11 +48,17 @@ export class UserProfileDropdownComponent implements OnDestroy {
   private flashTimeout: ReturnType<typeof setTimeout> | null = null;
 
   readonly menuOpenSg = signal(false);
+  readonly activityMenuOpenSg = signal(false);
   readonly profileMenuOpenSg = signal(false);
   readonly profileDialogOpenSg = signal(false);
   readonly changePasswordDialogOpenSg = signal(false);
   readonly filterSg = signal<NotificationFilter>('all');
   readonly notificationsSg = signal<Notification[]>([]);
+  readonly activitiesSg = signal<UserActivity[]>([]);
+  readonly activityLoadingSg = signal(false);
+  readonly activityLoadingMoreSg = signal(false);
+  readonly activityPageSg = signal(0);
+  readonly activityTotalSg = signal(0);
   readonly dismissingIdsSg = signal<Set<string>>(new Set());
   readonly shouldFlashBadgeSg = signal(false);
   readonly unreadCountSg = computed(
@@ -64,6 +75,10 @@ export class UserProfileDropdownComponent implements OnDestroy {
       (item) => this.mapTypeToFilter(item.notification_type) === filter
     );
   });
+  readonly hasMoreActivitiesSg = computed(
+    () => this.activitiesSg().length < this.activityTotalSg()
+  );
+  private readonly songAlbumCache = new Map<string, string>();
 
   constructor() {
     this.notificationService.notifications$
@@ -83,7 +98,7 @@ export class UserProfileDropdownComponent implements OnDestroy {
 
   @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent): void {
-    if (!this.menuOpenSg() && !this.profileMenuOpenSg()) {
+    if (!this.menuOpenSg() && !this.activityMenuOpenSg() && !this.profileMenuOpenSg()) {
       return;
     }
 
@@ -94,6 +109,7 @@ export class UserProfileDropdownComponent implements OnDestroy {
 
     if (!this.hostRef.nativeElement.contains(target)) {
       this.menuOpenSg.set(false);
+      this.activityMenuOpenSg.set(false);
       this.profileMenuOpenSg.set(false);
     }
   }
@@ -106,6 +122,7 @@ export class UserProfileDropdownComponent implements OnDestroy {
   }
 
   toggleNotificationsMenu(): void {
+    this.activityMenuOpenSg.set(false);
     this.profileMenuOpenSg.set(false);
     this.menuOpenSg.set(!this.menuOpenSg());
     if (this.menuOpenSg()) {
@@ -114,8 +131,20 @@ export class UserProfileDropdownComponent implements OnDestroy {
     }
   }
 
+  toggleActivityMenu(): void {
+    this.menuOpenSg.set(false);
+    this.profileMenuOpenSg.set(false);
+    const nextOpen = !this.activityMenuOpenSg();
+    this.activityMenuOpenSg.set(nextOpen);
+    if (nextOpen) {
+      this.resetActivities();
+      this.loadActivitiesPage(1, false);
+    }
+  }
+
   toggleProfileMenu(): void {
     this.menuOpenSg.set(false);
+    this.activityMenuOpenSg.set(false);
     this.profileMenuOpenSg.set(!this.profileMenuOpenSg());
   }
 
@@ -178,6 +207,50 @@ export class UserProfileDropdownComponent implements OnDestroy {
     this.router.navigate(['/']);
   }
 
+  async openActivity(item: UserActivity): Promise<void> {
+    this.activityMenuOpenSg.set(false);
+    const entityType = (item.entity_type ?? '').toUpperCase();
+    const entityId = item.entity_id ?? '';
+
+    if (entityType === 'SONG' && entityId) {
+      await this.openSongActivity(entityId);
+      return;
+    }
+
+    if (entityType === 'ARTIST' && entityId) {
+      this.router.navigate(['/artist', entityId]);
+      return;
+    }
+    if (entityType === 'GENRE' && entityId) {
+      this.router.navigate(['/genre', entityId]);
+      return;
+    }
+
+    this.router.navigate(['/']);
+  }
+
+  onActivityListScroll(event: Event): void {
+    const target = event.target as HTMLElement | null;
+    if (!target) {
+      return;
+    }
+
+    const nearBottom = target.scrollTop + target.clientHeight >= target.scrollHeight - 72;
+    if (!nearBottom) {
+      return;
+    }
+
+    if (
+      !this.hasMoreActivitiesSg() ||
+      this.activityLoadingSg() ||
+      this.activityLoadingMoreSg()
+    ) {
+      return;
+    }
+
+    this.loadActivitiesPage(this.activityPageSg() + 1, true);
+  }
+
   notificationFilters(): NotificationFilter[] {
     return ['all', 'albums', 'artists'];
   }
@@ -222,6 +295,10 @@ export class UserProfileDropdownComponent implements OnDestroy {
     return filter;
   }
 
+  trackActivity(_: number, item: UserActivity): string {
+    return item.event_id;
+  }
+
   openProfileDialog(): void {
     this.profileMenuOpenSg.set(false);
     this.profileDialogOpenSg.set(true);
@@ -242,6 +319,7 @@ export class UserProfileDropdownComponent implements OnDestroy {
 
   logout(): void {
     this.menuOpenSg.set(false);
+    this.activityMenuOpenSg.set(false);
     this.profileMenuOpenSg.set(false);
     this.authService.logout();
     this.router.navigate(['/']);
@@ -272,5 +350,130 @@ export class UserProfileDropdownComponent implements OnDestroy {
       updated.delete(id);
       this.dismissingIdsSg.set(updated);
     }, 220);
+  }
+
+  activityTitle(item: UserActivity): string {
+    const name = item.entity_name?.trim();
+    if (name) {
+      return name;
+    }
+
+    const entityType = (item.entity_type ?? '').toUpperCase();
+    if (entityType === 'ARTIST') return 'Unknown artist';
+    if (entityType === 'GENRE') return 'Unknown genre';
+    return 'Unknown song';
+  }
+
+  activityDescription(item: UserActivity): string {
+    if (item.type === 'SUBSCRIPTION_CREATED') {
+      const entityType = (item.entity_type ?? '').toUpperCase();
+      if (entityType === 'ARTIST') {
+        return 'Subscribed to new artist';
+      }
+      return 'Subscribed to new genre';
+    }
+
+    if (item.type === 'SUBSCRIPTION_DELETED') {
+      const entityType = (item.entity_type ?? '').toUpperCase();
+      if (entityType === 'ARTIST') {
+        return 'Unsubscribed from artist';
+      }
+      return 'Unsubscribed from genre';
+    }
+
+    if (item.type === 'LISTEN') {
+      return 'Played song';
+    }
+
+    return 'Activity';
+  }
+
+  activityWhen(item: UserActivity): string {
+    return this.formatTimeAgo(item.occurred_at || item.created_at);
+  }
+
+  private resetActivities(): void {
+    this.activitiesSg.set([]);
+    this.activityPageSg.set(0);
+    this.activityTotalSg.set(0);
+  }
+
+  private loadActivitiesPage(page: number, append: boolean): void {
+    if (page <= 1 && !append) {
+      this.activityLoadingSg.set(true);
+    } else {
+      this.activityLoadingMoreSg.set(true);
+    }
+
+    this.userActivityService.getMyActivities(page, 15).subscribe({
+      next: (response) => {
+        const items = response.items ?? [];
+        this.activityTotalSg.set(response.total ?? 0);
+        this.activityPageSg.set(response.page ?? page);
+
+        if (!append) {
+          this.activitiesSg.set(items);
+        } else {
+          this.activitiesSg.set(this.mergeActivities(this.activitiesSg(), items));
+        }
+
+        this.activityLoadingSg.set(false);
+        this.activityLoadingMoreSg.set(false);
+      },
+      error: () => {
+        if (!append) {
+          this.activitiesSg.set([]);
+        }
+        this.activityLoadingSg.set(false);
+        this.activityLoadingMoreSg.set(false);
+      },
+    });
+  }
+
+  private mergeActivities(existing: UserActivity[], incoming: UserActivity[]): UserActivity[] {
+    const byId = new Map<string, UserActivity>();
+    for (const item of existing) {
+      byId.set(item.event_id, item);
+    }
+    for (const item of incoming) {
+      byId.set(item.event_id, item);
+    }
+    return Array.from(byId.values());
+  }
+
+  private async openSongActivity(songId: string): Promise<void> {
+    const cachedAlbumId = this.songAlbumCache.get(songId);
+    if (cachedAlbumId) {
+      this.router.navigate(['/album', cachedAlbumId]);
+      return;
+    }
+
+    const size = 100;
+    let page = 1;
+
+    try {
+      while (true) {
+        const response = await firstValueFrom(this.albumService.getAlbums(page, size));
+        const albums = response.items ?? [];
+        const matched = albums.find((album) => (album.songs ?? []).some((song) => song.id === songId));
+        if (matched) {
+          this.songAlbumCache.set(songId, matched.id);
+          this.router.navigate(['/album', matched.id]);
+          return;
+        }
+
+        const total = response.total ?? 0;
+        const reachedEnd = page * size >= total || albums.length === 0;
+        if (reachedEnd || page >= 20) {
+          break;
+        }
+
+        page += 1;
+      }
+    } catch {
+      // no-op fallback below
+    }
+
+    this.router.navigate(['/']);
   }
 }

--- a/frontend/src/app/shared/components/page/components/homepage-left-sidebar/homepage-left-sidebar.html
+++ b/frontend/src/app/shared/components/page/components/homepage-left-sidebar/homepage-left-sidebar.html
@@ -37,30 +37,4 @@
     </div>
   </div>
 
-  <div class="homepage-left-sidebar__bottom">
-    <div class="homepage-left-sidebar__section">
-      <h3 class="homepage-left-sidebar__title">Recent activity</h3>
-      <nav class="homepage-left-sidebar__list" aria-label="Recent activity">
-        @if (recentActivitySg().length === 0) {
-          <p class="homepage-left-sidebar__item-note">No recent activity yet.</p>
-        } @else {
-          @for (item of recentActivitySg(); track item.key) {
-            <a class="homepage-left-sidebar__item" [routerLink]="item.href">
-              <app-cover-art
-                class="homepage-left-sidebar__cover homepage-left-sidebar__cover--square"
-                [name]="item.label"
-                [square]="true"
-                [size]="34"
-                [fontSize]="14"
-              />
-              <span class="homepage-left-sidebar__item-meta">
-                <span class="homepage-left-sidebar__item-label">{{ item.label }}</span>
-                <span class="homepage-left-sidebar__item-note">{{ item.meta }}</span>
-              </span>
-            </a>
-          }
-        }
-      </nav>
-    </div>
-  </div>
 </section>

--- a/frontend/src/app/shared/components/page/components/homepage-left-sidebar/homepage-left-sidebar.html
+++ b/frontend/src/app/shared/components/page/components/homepage-left-sidebar/homepage-left-sidebar.html
@@ -36,5 +36,4 @@
       </nav>
     </div>
   </div>
-
 </section>

--- a/frontend/src/app/shared/components/page/components/homepage-left-sidebar/homepage-left-sidebar.html
+++ b/frontend/src/app/shared/components/page/components/homepage-left-sidebar/homepage-left-sidebar.html
@@ -39,12 +39,12 @@
 
   <div class="homepage-left-sidebar__bottom">
     <div class="homepage-left-sidebar__section">
-      <h3 class="homepage-left-sidebar__title">Recently played</h3>
+      <h3 class="homepage-left-sidebar__title">Recent activity</h3>
       <nav class="homepage-left-sidebar__list" aria-label="Recent activity">
         @if (recentActivitySg().length === 0) {
-          <p class="homepage-left-sidebar__item-note">No recent playback yet.</p>
+          <p class="homepage-left-sidebar__item-note">No recent activity yet.</p>
         } @else {
-          @for (item of recentActivitySg(); track item.label + ':' + item.meta) {
+          @for (item of recentActivitySg(); track item.key) {
             <a class="homepage-left-sidebar__item" [routerLink]="item.href">
               <app-cover-art
                 class="homepage-left-sidebar__cover homepage-left-sidebar__cover--square"

--- a/frontend/src/app/shared/components/page/components/homepage-left-sidebar/homepage-left-sidebar.ts
+++ b/frontend/src/app/shared/components/page/components/homepage-left-sidebar/homepage-left-sidebar.ts
@@ -1,14 +1,12 @@
 import { CommonModule } from '@angular/common';
-import { Component, DestroyRef, computed, effect, inject, signal } from '@angular/core';
+import { Component, DestroyRef, effect, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { AuthService } from '@app/services/auth.service';
 import { SubscriptionService } from '@app/services/subscription.service';
-import { UserActivity, UserActivityService } from '@app/services/user-activity.service';
 import { CoverArtComponent } from '@app/shared/components/cover-art/cover-art';
 
 type SidebarShortcut = { label: string; href: string };
-type RecentActivity = { key: string; label: string; href: string; meta: string };
 
 @Component({
   selector: 'app-homepage-left-sidebar',
@@ -20,19 +18,15 @@ type RecentActivity = { key: string; label: string; href: string; meta: string }
 export class HomepageLeftSidebarComponent {
   private readonly authService = inject(AuthService);
   private readonly subscriptionService = inject(SubscriptionService);
-  private readonly userActivityService = inject(UserActivityService);
   private readonly destroyRef = inject(DestroyRef);
 
   readonly followedArtistsSg = signal<SidebarShortcut[]>([]);
   readonly followedGenresSg = signal<SidebarShortcut[]>([]);
-  private readonly userActivitiesSg = signal<UserActivity[]>([]);
-  readonly recentActivitySg = computed<RecentActivity[]>(() => this.mapActivities(this.userActivitiesSg()));
 
   constructor() {
     this.subscriptionService.changes$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       if (this.authService.currentUserIdSg()) {
         this.loadSubscriptions();
-        this.loadActivities();
       }
     });
 
@@ -41,12 +35,10 @@ export class HomepageLeftSidebarComponent {
       if (!userId) {
         this.followedArtistsSg.set([]);
         this.followedGenresSg.set([]);
-        this.userActivitiesSg.set([]);
         return;
       }
 
       this.loadSubscriptions();
-      this.loadActivities();
     });
   }
 
@@ -79,104 +71,5 @@ export class HomepageLeftSidebarComponent {
           this.followedGenresSg.set([]);
         },
       });
-  }
-
-  private loadActivities(): void {
-    this.userActivityService
-      .getMyActivities(1, 12)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (response) => {
-          this.userActivitiesSg.set(response.items ?? []);
-        },
-        error: () => {
-          this.userActivitiesSg.set([]);
-        },
-      });
-  }
-
-  private mapActivities(activities: UserActivity[]): RecentActivity[] {
-    return activities.slice(0, 6).map((activity) => {
-      const entityType = (activity.entity_type ?? '').toUpperCase();
-      const entityID = activity.entity_id ?? '';
-      const label = activity.entity_name?.trim() || this.defaultLabel(activity);
-      const href = this.entityHref(entityType, entityID);
-      const meta = this.activityMeta(activity);
-      const key = activity.event_id || `${activity.type}:${entityID}:${activity.occurred_at}`;
-
-      return { key, label, href, meta };
-    });
-  }
-
-  private defaultLabel(activity: UserActivity): string {
-    switch (activity.type) {
-      case 'LISTEN':
-      case 'RATING_CREATED':
-      case 'RATING_UPDATED':
-        return 'Song';
-      case 'SUBSCRIPTION_CREATED':
-      case 'SUBSCRIPTION_DELETED':
-        return activity.entity_type === 'ARTIST' ? 'Artist' : 'Genre';
-      default:
-        return 'Activity';
-    }
-  }
-
-  private entityHref(entityType: string, entityID: string): string {
-    if (!entityID) {
-      return '/';
-    }
-
-    if (entityType === 'SONG') {
-      return '/';
-    }
-    if (entityType === 'ARTIST') {
-      return `/artist/${entityID}`;
-    }
-    if (entityType === 'GENRE') {
-      return `/genre/${entityID}`;
-    }
-
-    return '/';
-  }
-
-  private activityMeta(activity: UserActivity): string {
-    const when = this.relativeTime(activity.occurred_at || activity.created_at);
-
-    switch (activity.type) {
-      case 'LISTEN':
-        return `Played ${when}`;
-      case 'SUBSCRIPTION_CREATED':
-        return `Subscribed ${when}`;
-      case 'SUBSCRIPTION_DELETED':
-        return `Unsubscribed ${when}`;
-      case 'RATING_CREATED':
-      case 'RATING_UPDATED':
-        return `Rated ${activity.rating_value ?? 0}/5 ${when}`;
-      default:
-        return when;
-    }
-  }
-
-  private relativeTime(isoDate: string): string {
-    const timestamp = new Date(isoDate).getTime();
-    if (!Number.isFinite(timestamp)) {
-      return 'recently';
-    }
-
-    const diffMs = Date.now() - timestamp;
-    const diffMinutes = Math.floor(diffMs / 60000);
-    if (diffMinutes <= 0) {
-      return 'just now';
-    }
-    if (diffMinutes < 60) {
-      return `${diffMinutes}m ago`;
-    }
-    const diffHours = Math.floor(diffMinutes / 60);
-    if (diffHours < 24) {
-      return `${diffHours}h ago`;
-    }
-    const diffDays = Math.floor(diffHours / 24);
-    return `${diffDays}d ago`;
   }
 }

--- a/frontend/src/app/shared/components/page/components/homepage-left-sidebar/homepage-left-sidebar.ts
+++ b/frontend/src/app/shared/components/page/components/homepage-left-sidebar/homepage-left-sidebar.ts
@@ -3,12 +3,12 @@ import { Component, DestroyRef, computed, effect, inject, signal } from '@angula
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { AuthService } from '@app/services/auth.service';
-import { PlaybackService } from '@app/services/playback.service';
 import { SubscriptionService } from '@app/services/subscription.service';
+import { UserActivity, UserActivityService } from '@app/services/user-activity.service';
 import { CoverArtComponent } from '@app/shared/components/cover-art/cover-art';
 
 type SidebarShortcut = { label: string; href: string };
-type RecentActivity = { label: string; href: string; meta: string };
+type RecentActivity = { key: string; label: string; href: string; meta: string };
 
 @Component({
   selector: 'app-homepage-left-sidebar',
@@ -19,27 +19,20 @@ type RecentActivity = { label: string; href: string; meta: string };
 })
 export class HomepageLeftSidebarComponent {
   private readonly authService = inject(AuthService);
-  private readonly playback = inject(PlaybackService);
   private readonly subscriptionService = inject(SubscriptionService);
+  private readonly userActivityService = inject(UserActivityService);
   private readonly destroyRef = inject(DestroyRef);
 
   readonly followedArtistsSg = signal<SidebarShortcut[]>([]);
   readonly followedGenresSg = signal<SidebarShortcut[]>([]);
-  readonly recentActivitySg = computed<RecentActivity[]>(() =>
-    this.playback
-      .playHistorySg()
-      .slice(0, 6)
-      .map((entry) => ({
-        label: entry.title,
-        href: `/albums/${entry.albumId}`,
-        meta: `Played ${this.relativeTime(entry.playedAt)}`,
-      }))
-  );
+  private readonly userActivitiesSg = signal<UserActivity[]>([]);
+  readonly recentActivitySg = computed<RecentActivity[]>(() => this.mapActivities(this.userActivitiesSg()));
 
   constructor() {
     this.subscriptionService.changes$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       if (this.authService.currentUserIdSg()) {
         this.loadSubscriptions();
+        this.loadActivities();
       }
     });
 
@@ -48,10 +41,12 @@ export class HomepageLeftSidebarComponent {
       if (!userId) {
         this.followedArtistsSg.set([]);
         this.followedGenresSg.set([]);
+        this.userActivitiesSg.set([]);
         return;
       }
 
       this.loadSubscriptions();
+      this.loadActivities();
     });
   }
 
@@ -84,6 +79,83 @@ export class HomepageLeftSidebarComponent {
           this.followedGenresSg.set([]);
         },
       });
+  }
+
+  private loadActivities(): void {
+    this.userActivityService
+      .getMyActivities(1, 12)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (response) => {
+          this.userActivitiesSg.set(response.items ?? []);
+        },
+        error: () => {
+          this.userActivitiesSg.set([]);
+        },
+      });
+  }
+
+  private mapActivities(activities: UserActivity[]): RecentActivity[] {
+    return activities.slice(0, 6).map((activity) => {
+      const entityType = (activity.entity_type ?? '').toUpperCase();
+      const entityID = activity.entity_id ?? '';
+      const label = activity.entity_name?.trim() || this.defaultLabel(activity);
+      const href = this.entityHref(entityType, entityID);
+      const meta = this.activityMeta(activity);
+      const key = activity.event_id || `${activity.type}:${entityID}:${activity.occurred_at}`;
+
+      return { key, label, href, meta };
+    });
+  }
+
+  private defaultLabel(activity: UserActivity): string {
+    switch (activity.type) {
+      case 'LISTEN':
+      case 'RATING_CREATED':
+      case 'RATING_UPDATED':
+        return 'Song';
+      case 'SUBSCRIPTION_CREATED':
+      case 'SUBSCRIPTION_DELETED':
+        return activity.entity_type === 'ARTIST' ? 'Artist' : 'Genre';
+      default:
+        return 'Activity';
+    }
+  }
+
+  private entityHref(entityType: string, entityID: string): string {
+    if (!entityID) {
+      return '/';
+    }
+
+    if (entityType === 'SONG') {
+      return '/';
+    }
+    if (entityType === 'ARTIST') {
+      return `/artist/${entityID}`;
+    }
+    if (entityType === 'GENRE') {
+      return `/genre/${entityID}`;
+    }
+
+    return '/';
+  }
+
+  private activityMeta(activity: UserActivity): string {
+    const when = this.relativeTime(activity.occurred_at || activity.created_at);
+
+    switch (activity.type) {
+      case 'LISTEN':
+        return `Played ${when}`;
+      case 'SUBSCRIPTION_CREATED':
+        return `Subscribed ${when}`;
+      case 'SUBSCRIPTION_DELETED':
+        return `Unsubscribed ${when}`;
+      case 'RATING_CREATED':
+      case 'RATING_UPDATED':
+        return `Rated ${activity.rating_value ?? 0}/5 ${when}`;
+      default:
+        return when;
+    }
   }
 
   private relativeTime(isoDate: string): string {

--- a/rating-service/main.go
+++ b/rating-service/main.go
@@ -73,7 +73,6 @@ var (
 			err = jsc.EnsureStream(ctx, events.RATINGS_STREAM, []string{
 				events.SUBJECT_RATING_CREATED,
 				events.SUBJECT_RATING_UPDATED,
-				events.SUBJECT_RATING_DELETED,
 			})
 			if err != nil {
 				err = fmt.Errorf("failed to ensure ratings stream: %w", err)

--- a/rating-service/services/rating_service.go
+++ b/rating-service/services/rating_service.go
@@ -78,7 +78,7 @@ func (s *RatingService) CreateRating(req *dtos.CreateRatingDto, ctx context.Cont
 	songExistsCtx, songExistsSpan := s.tr.Start(ratingCtx, "rating.create.exists")
 	defer songExistsSpan.End()
 
-	_, err := s.gcc.GetSong(songExistsCtx, req.SongID)
+	songTitle, err := s.gcc.GetSong(songExistsCtx, req.SongID)
 	if err != nil {
 		songExistsSpan.RecordError(err)
 		if errors.Is(err, gobreaker.ErrOpenState) {
@@ -127,6 +127,7 @@ func (s *RatingService) CreateRating(req *dtos.CreateRatingDto, ctx context.Cont
 	payload := events.RatingEventPayload{
 		UserID:    ratingEntity.UserID.Hex(),
 		SongID:    ratingEntity.SongID.Hex(),
+		SongTitle: songTitle,
 		Rating:    ratingEntity.Value,
 		EventID:   primitive.NewObjectID().Hex(),
 		CreatedAt: ratingEntity.CreatedAt,
@@ -193,35 +194,6 @@ func (s *RatingService) DeleteRating(ratingID primitive.ObjectID, ctx context.Co
 
 	if deletedCount != 1 {
 		return ErrRatingNotFound
-	}
-
-	// Publish rating deleted event with retry for reliability
-	payload := events.RatingEventPayload{
-		UserID:    userID.Hex(),
-		SongID:    existing.SongID.Hex(),
-		Rating:    existing.Value,
-		EventID:   primitive.NewObjectID().Hex(),
-		CreatedAt: existing.CreatedAt,
-	}
-
-	publishCtx, publishSpan := s.tr.Start(ctx, "rating.delete.publish")
-	defer publishSpan.End()
-	if s.jsc == nil {
-		return nil
-	}
-
-	err = retry.Do(
-		func() error {
-			return s.jsc.Publish(publishCtx, events.SUBJECT_RATING_DELETED, payload)
-		},
-		retry.Attempts(3),
-		retry.Delay(time.Second),
-		retry.DelayType(retry.BackOffDelay),
-		retry.Context(publishCtx),
-	)
-	if err != nil {
-		publishSpan.RecordError(err)
-		logging.Errorf(publishCtx, "failed to publish rating deleted event: %v", err)
 	}
 
 	return nil
@@ -351,10 +323,17 @@ func (s *RatingService) UpdateRating(ctx context.Context, ratingIdStr string, dt
 		return nil, err
 	}
 
+	songId := rating.SongID.Hex()
+	songTitle, err := s.gcc.GetSong(ctx, songId)
+	if err != nil {
+		return nil, err
+	}
+
 	// Publish rating updated event with retry for reliability
 	payload := events.RatingEventPayload{
 		UserID:    rating.UserID.Hex(),
-		SongID:    rating.SongID.Hex(),
+		SongID:    songId,
+		SongTitle: songTitle,
 		Rating:    rating.Value,
 		EventID:   primitive.NewObjectID().Hex(),
 		CreatedAt: rating.CreatedAt,

--- a/subscription-service/main.go
+++ b/subscription-service/main.go
@@ -88,6 +88,15 @@ var (
 				return h, shutdown, err
 			}
 
+			if err = jsc.EnsureStream(
+				ctx,
+				events.SUBSCRIPTIONS_STREAM,
+				[]string{events.SUBJECT_SUBSCRIPTION_CREATED, events.SUBJECT_SUBSCRIPTION_DELETED},
+			); err != nil {
+				err = fmt.Errorf("failed to ensure subscriptions stream: %w", err)
+				return h, shutdown, err
+			}
+
 			gcc := createAdapters(gc)
 			sr := createRepositories(dbc)
 			ss := createServices(sr, gcc, jsc)

--- a/subscription-service/services/subscription_service.go
+++ b/subscription-service/services/subscription_service.go
@@ -225,6 +225,21 @@ func (s *SubscriptionService) Subscribe(req *dtos.CreateSubscriptionDto, ctx con
 		}
 	}
 
+	eventPayload := toSubscriptionActivityEvent(se)
+	if eventPayload != nil {
+		if err := retry.Do(
+			func() error {
+				return s.jsc.Publish(ctx, events.SUBJECT_SUBSCRIPTION_CREATED, eventPayload)
+			},
+			retry.Attempts(3),
+			retry.Delay(time.Second),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Context(ctx),
+		); err != nil {
+			logging.Errorf(ctx, "failed to publish subscription created event: %v", err)
+		}
+	}
+
 	return nil
 }
 
@@ -270,6 +285,23 @@ func (s *SubscriptionService) Unsubscribe(entityId primitive.ObjectID, ctx conte
 
 	if ddc != 1 {
 		return ErrSubscriptionNotFound
+	}
+
+	eventPayload := toSubscriptionActivityEvent(&subs[0])
+	if eventPayload != nil {
+		// Set the event creation time to now for unsubscription events
+		eventPayload.CreatedAt = time.Now().UTC()
+		if err := retry.Do(
+			func() error {
+				return s.jsc.Publish(ctx, events.SUBJECT_SUBSCRIPTION_DELETED, eventPayload)
+			},
+			retry.Attempts(3),
+			retry.Delay(time.Second),
+			retry.DelayType(retry.BackOffDelay),
+			retry.Context(ctx),
+		); err != nil {
+			logging.Errorf(ctx, "failed to publish subscription deleted event: %v", err)
+		}
 	}
 
 	return nil
@@ -394,5 +426,26 @@ func toSubscriptionEvent(userID string, genreID string) *events.GenreSubscriptio
 	return &events.GenreSubscriptionEventPayload{
 		UserID:  userID,
 		GenreID: genreID,
+	}
+}
+
+func toSubscriptionActivityEvent(se *entities.Subscription) *events.SubscriptionEventPayload {
+	var entityType events.SubscriptionEntityType
+	switch se.Type {
+	case subscription.ArtistSubscription:
+		entityType = events.SubscriptionEntityArtist
+	case subscription.GenreSubscription:
+		entityType = events.SubscriptionEntityGenre
+	default:
+		return nil
+	}
+
+	return &events.SubscriptionEventPayload{
+		UserID:     se.SubscriberID.Hex(),
+		EntityID:   se.EntityID.Hex(),
+		EntityName: se.EntityName,
+		EntityType: entityType,
+		EventID:    primitive.NewObjectID().Hex(),
+		CreatedAt:  se.SubscribedAt,
 	}
 }

--- a/user-service/consumers/user_activity_consumer.go
+++ b/user-service/consumers/user_activity_consumer.go
@@ -1,0 +1,108 @@
+package consumers
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/vanjmali/spotlite/common-lib/events"
+	"github.com/vanjmali/spotlite/common-lib/logging"
+	"github.com/vanjmali/spotlite/user-service/entities"
+	"github.com/vanjmali/spotlite/user-service/services"
+)
+
+type UserActivityConsumer struct {
+	s *services.UserActivityService
+}
+
+func NewUserActivityConsumer(s *services.UserActivityService) *UserActivityConsumer {
+	return &UserActivityConsumer{s: s}
+}
+
+func (c *UserActivityConsumer) HandleListenCreated(ctx context.Context, msg jetstream.Msg) error {
+	var payload events.ListenEventPayload
+	if err := json.Unmarshal(msg.Data(), &payload); err != nil {
+		logging.Errorf(ctx, "failed to unmarshal listen event: %v", err)
+		return err
+	}
+
+	return c.s.Append(ctx, entities.UserActivity{
+		EventID:    payload.EventID,
+		UserID:     payload.UserID,
+		Type:       entities.ActivityListen,
+		EntityID:   payload.SongID,
+		EntityName: payload.SongTitle,
+		EntityType: "SONG",
+		OccurredAt: atOrNow(payload.CreatedAt),
+	})
+}
+
+func (c *UserActivityConsumer) HandleRatingCreated(ctx context.Context, msg jetstream.Msg) error {
+	return c.handleRatingEvent(ctx, msg, entities.ActivityRatingCreate)
+}
+
+func (c *UserActivityConsumer) HandleRatingUpdated(ctx context.Context, msg jetstream.Msg) error {
+	return c.handleRatingEvent(ctx, msg, entities.ActivityRatingUpdate)
+}
+
+func (c *UserActivityConsumer) HandleSubscriptionCreated(ctx context.Context, msg jetstream.Msg) error {
+	return c.handleSubscriptionEvent(ctx, msg, entities.ActivitySubscriptionCreate)
+}
+
+func (c *UserActivityConsumer) HandleSubscriptionDeleted(ctx context.Context, msg jetstream.Msg) error {
+	return c.handleSubscriptionEvent(ctx, msg, entities.ActivitySubscriptionDelete)
+}
+
+func (c *UserActivityConsumer) handleRatingEvent(
+	ctx context.Context,
+	msg jetstream.Msg,
+	activityType entities.ActivityType,
+) error {
+	var payload events.RatingEventPayload
+	if err := json.Unmarshal(msg.Data(), &payload); err != nil {
+		logging.Errorf(ctx, "failed to unmarshal rating event: %v", err)
+		return err
+	}
+
+	ratingValue := payload.Rating
+	return c.s.Append(ctx, entities.UserActivity{
+		EventID:     payload.EventID,
+		UserID:      payload.UserID,
+		Type:        activityType,
+		EntityID:    payload.SongID,
+		EntityName:  payload.SongTitle,
+		EntityType:  "SONG",
+		RatingValue: &ratingValue,
+		OccurredAt:  atOrNow(payload.CreatedAt),
+	})
+}
+
+func (c *UserActivityConsumer) handleSubscriptionEvent(
+	ctx context.Context,
+	msg jetstream.Msg,
+	activityType entities.ActivityType,
+) error {
+	var payload events.SubscriptionEventPayload
+	if err := json.Unmarshal(msg.Data(), &payload); err != nil {
+		logging.Errorf(ctx, "failed to unmarshal subscription event: %v", err)
+		return err
+	}
+
+	return c.s.Append(ctx, entities.UserActivity{
+		EventID:    payload.EventID,
+		UserID:     payload.UserID,
+		Type:       activityType,
+		EntityID:   payload.EntityID,
+		EntityName: payload.EntityName,
+		EntityType: string(payload.EntityType),
+		OccurredAt: atOrNow(payload.CreatedAt),
+	})
+}
+
+func atOrNow(t time.Time) time.Time {
+	if t.IsZero() {
+		return time.Now().UTC()
+	}
+	return t.UTC()
+}

--- a/user-service/entities/user_activity.go
+++ b/user-service/entities/user_activity.go
@@ -1,0 +1,25 @@
+package entities
+
+import "time"
+
+type ActivityType string
+
+const (
+	ActivityListen             ActivityType = "LISTEN"
+	ActivitySubscriptionCreate ActivityType = "SUBSCRIPTION_CREATED"
+	ActivitySubscriptionDelete ActivityType = "SUBSCRIPTION_DELETED"
+	ActivityRatingCreate       ActivityType = "RATING_CREATED"
+	ActivityRatingUpdate       ActivityType = "RATING_UPDATED"
+)
+
+type UserActivity struct {
+	EventID     string       `bson:"event_id" json:"event_id"`
+	UserID      string       `bson:"user_id" json:"user_id"`
+	Type        ActivityType `bson:"type" json:"type"`
+	EntityID    string       `bson:"entity_id,omitempty" json:"entity_id,omitempty"`
+	EntityName  string       `bson:"entity_name,omitempty" json:"entity_name,omitempty"`
+	EntityType  string       `bson:"entity_type,omitempty" json:"entity_type,omitempty"`
+	RatingValue *int         `bson:"rating_value,omitempty" json:"rating_value,omitempty"`
+	OccurredAt  time.Time    `bson:"occurred_at" json:"occurred_at"`
+	CreatedAt   time.Time    `bson:"created_at" json:"created_at"`
+}

--- a/user-service/handlers/user_activity_handler.go
+++ b/user-service/handlers/user_activity_handler.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/vanjmali/spotlite/common-lib/pagination"
+	"github.com/vanjmali/spotlite/common-lib/respond"
+	"github.com/vanjmali/spotlite/user-service/services"
+)
+
+type UserActivityHandler struct {
+	s *services.UserActivityService
+}
+
+func NewUserActivityHandler(s *services.UserActivityService) *UserActivityHandler {
+	return &UserActivityHandler{s: s}
+}
+
+func (h *UserActivityHandler) HandleGetMyActivities(w http.ResponseWriter, r *http.Request) {
+	p := pagination.ParsePagination(r.URL.Query())
+
+	response, err := h.s.ListMyActivities(r.Context(), p.Page, p.Size)
+	if err != nil {
+		_ = respond.InternalServerError(w)
+		return
+	}
+
+	_ = respond.OkJson(w, response)
+}

--- a/user-service/main.go
+++ b/user-service/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/go-playground/validator/v10"
@@ -16,6 +17,7 @@ import (
 	"github.com/vanjmali/spotlite/common-lib/server"
 	"github.com/vanjmali/spotlite/common-lib/utils"
 	"github.com/vanjmali/spotlite/common-lib/validations"
+	"github.com/vanjmali/spotlite/user-service/consumers"
 	"github.com/vanjmali/spotlite/user-service/handlers"
 	"github.com/vanjmali/spotlite/user-service/infrastructure/mailing"
 	"github.com/vanjmali/spotlite/user-service/infrastructure/mongo"
@@ -60,11 +62,19 @@ var (
 			}
 			// Cleanup resources on error
 			var asynqShutdown func() error
+			var stopConsumers func()
+			var consumerWg sync.WaitGroup
 			defer func() {
 				if err == nil {
 					// No error, do nothing when function exits
 					return
 				}
+
+				if stopConsumers != nil {
+					stopConsumers()
+					consumerWg.Wait()
+				}
+
 				_ = mc.Disconnect(ctx)
 				_ = mail.Close()
 				jsc.Close()
@@ -80,17 +90,54 @@ var (
 				return h, shutdown, err
 			}
 
-			ur, rtr, prr, err := createRepositories(ctx, mc)
+			if err = jsc.EnsureStream(
+				ctx,
+				events.LISTENS_STREAM,
+				[]string{events.SUBJECT_LISTEN_CREATED},
+			); err != nil {
+				err = fmt.Errorf("failed to ensure listens stream: %w", err)
+				return h, shutdown, err
+			}
+
+			if err = jsc.EnsureStream(
+				ctx,
+				events.RATINGS_STREAM,
+				[]string{
+					events.SUBJECT_RATING_CREATED,
+					events.SUBJECT_RATING_UPDATED,
+				},
+			); err != nil {
+				err = fmt.Errorf("failed to ensure ratings stream: %w", err)
+				return h, shutdown, err
+			}
+
+			if err = jsc.EnsureStream(
+				ctx,
+				events.SUBSCRIPTIONS_STREAM,
+				[]string{events.SUBJECT_SUBSCRIPTION_CREATED, events.SUBJECT_SUBSCRIPTION_DELETED},
+			); err != nil {
+				err = fmt.Errorf("failed to ensure subscriptions stream: %w", err)
+				return h, shutdown, err
+			}
+
+			ur, rtr, prr, uar, err := createRepositories(ctx, mc)
 			if err != nil {
 				err = fmt.Errorf("failed to create repositories: %w", err)
 				return h, shutdown, err
 			}
 
-			ms, us, rts, prs := createServices(mail, ur, rtr, prr, jsc)
-			h = createHandlers(v, us, rts, prs)
+			ms, us, rts, prs, uas := createServices(mail, ur, rtr, prr, uar, jsc)
+			h = createHandlers(v, us, rts, prs, uas)
+
+			stopConsumers = setupActivityConsumers(ctx, jsc, uas, &consumerWg)
 
 			asynqShutdown = setupAsynq(us, ms)
 			shutdown = func() error {
+				if stopConsumers != nil {
+					stopConsumers()
+					consumerWg.Wait()
+				}
+
 				if err := mc.Disconnect(ctx); err != nil && !errors.Is(err, mongodriver.ErrClientDisconnected) {
 					return fmt.Errorf("failed to disconnect mongo client: %w", err)
 				}
@@ -145,21 +192,28 @@ func createRepositories(ctx context.Context, mongo *mongodriver.Client) (
 	services.UserRepository,
 	services.RefreshTokenRepository,
 	services.PasswordRecoveryRepository,
+	services.UserActivityRepository,
 	error,
 ) {
 	name := utils.MustGetEnv("DB_NAME")
 	ur := repositories.NewUserRepositoryMongo(name, "users", mongo)
 	rtr := repositories.NewRefreshTokenRepository(name, "refresh_tokens", mongo)
 	prr := repositories.NewPasswordRecoveryRepository(name, "password_recovery_tokens", mongo)
+	uar := repositories.NewUserActivityRepository(name, "user_activity_events", mongo)
 
 	if err := ur.EnsureUserIndexes(ctx); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to ensure user indexes: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to ensure user indexes: %w", err)
 	}
 
 	if err := rtr.EnsureRefreshIndexes(ctx); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to ensure refresh token indexes: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to ensure refresh token indexes: %w", err)
 	}
-	return ur, rtr, prr, nil
+
+	if err := uar.EnsureIndexes(ctx); err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to ensure user activity indexes: %w", err)
+	}
+
+	return ur, rtr, prr, uar, nil
 }
 
 func createServices(
@@ -167,11 +221,13 @@ func createServices(
 	ur services.UserRepository,
 	rr services.RefreshTokenRepository,
 	pt services.PasswordRecoveryRepository,
+	uar services.UserActivityRepository,
 	jsc *events.JetStreamClient) (
 	*services.MailService,
 	*services.UserService,
 	*services.RefreshTokenService,
 	*services.PasswordRecoveryService,
+	*services.UserActivityService,
 ) {
 	mailCfg := services.MailConfig{
 		VerificationURL:  utils.MustGetEnv("SRV_USER_VERIFY_URL"),
@@ -183,8 +239,9 @@ func createServices(
 	us := services.NewUserService(ur, ms, jsc)
 	rts := services.NewRefreshTokenService(rr)
 	prs := services.NewPasswordRecoveryService(ur, pt, ms)
+	uas := services.NewUserActivityService(uar)
 
-	return ms, us, rts, prs
+	return ms, us, rts, prs, uas
 }
 
 func createHandlers(
@@ -192,13 +249,15 @@ func createHandlers(
 	us *services.UserService,
 	rts *services.RefreshTokenService,
 	prs *services.PasswordRecoveryService,
+	uas *services.UserActivityService,
 ) http.Handler {
 	uh := handlers.NewUserHandler(*us, *v, *rts)
+	ah := handlers.NewUserActivityHandler(uas)
 
 	rth := handlers.NewRefreshTokenHandler(*rts, *us, *v)
 	prh := handlers.NewPasswordRecoveryHandler(*prs, *v)
 
-	return routers.HandleRequests(uh, rth, prh)
+	return routers.HandleRequests(uh, rth, prh, ah)
 }
 
 // setupAsynq initializes and starts the asynq server, client, scheduler, workers and task router.
@@ -228,6 +287,67 @@ func setupAsynq(us *services.UserService, ms *services.MailService) func() error
 	as.Start(mux)
 
 	return as.Stop
+}
+
+func setupActivityConsumers(
+	ctx context.Context,
+	jsc *events.JetStreamClient,
+	uas *services.UserActivityService,
+	wg *sync.WaitGroup,
+) func() {
+	consumer := consumers.NewUserActivityConsumer(uas)
+	consumerCtx, cancel := context.WithCancel(ctx)
+
+	configs := []events.ConsumerConfig{
+		{
+			Stream:  events.LISTENS_STREAM,
+			Subject: events.SUBJECT_LISTEN_CREATED,
+			Durable: events.LISTEN_DURABLE,
+			Handler: consumer.HandleListenCreated,
+		},
+		{
+			Stream:  events.RATINGS_STREAM,
+			Subject: events.SUBJECT_RATING_CREATED,
+			Durable: events.RATING_CREATED_DURABLE,
+			Handler: consumer.HandleRatingCreated,
+		},
+		{
+			Stream:  events.RATINGS_STREAM,
+			Subject: events.SUBJECT_RATING_UPDATED,
+			Durable: events.RATING_UPDATED_DURABLE,
+			Handler: consumer.HandleRatingUpdated,
+		},
+		{
+			Stream:  events.SUBSCRIPTIONS_STREAM,
+			Subject: events.SUBJECT_SUBSCRIPTION_CREATED,
+			Durable: events.SUBSCRIPTION_CREATED_DURABLE,
+			Handler: consumer.HandleSubscriptionCreated,
+		},
+		{
+			Stream:  events.SUBSCRIPTIONS_STREAM,
+			Subject: events.SUBJECT_SUBSCRIPTION_DELETED,
+			Durable: events.SUBSCRIPTION_DELETED_DURABLE,
+			Handler: consumer.HandleSubscriptionDeleted,
+		},
+	}
+
+	for _, cfg := range configs {
+		wg.Add(1)
+		go func(config events.ConsumerConfig) {
+			defer wg.Done()
+			if err := jsc.StartConsumer(
+				consumerCtx,
+				config.Stream,
+				config.Subject,
+				config.Durable,
+				config.Handler,
+			); err != nil && !errors.Is(err, context.Canceled) {
+				logging.Errorf(context.Background(), "activity consumer %s failed: %v", config.Durable, err)
+			}
+		}(cfg)
+	}
+
+	return cancel
 }
 
 func main() {

--- a/user-service/repositories/user_activity_repository.go
+++ b/user-service/repositories/user_activity_repository.go
@@ -1,0 +1,86 @@
+package repositories
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/vanjmali/spotlite/user-service/entities"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type UserActivityRepository struct {
+	DbName   string
+	CollName string
+	Client   *mongo.Client
+}
+
+func NewUserActivityRepository(dbName string, collName string, c *mongo.Client) *UserActivityRepository {
+	r := UserActivityRepository{Client: c, DbName: dbName, CollName: collName}
+	return &r
+}
+
+func (r *UserActivityRepository) getCollection() *mongo.Collection {
+	return r.Client.Database(r.DbName).Collection(r.CollName)
+}
+
+func (r *UserActivityRepository) EnsureIndexes(ctx context.Context) error {
+	c := r.getCollection()
+	_, err := c.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "event_id", Value: 1}},
+			Options: options.Index().SetName("activity_event_id_unique").SetUnique(true),
+		},
+		{
+			Keys:    bson.D{{Key: "user_id", Value: 1}, {Key: "occurred_at", Value: -1}},
+			Options: options.Index().SetName("activity_user_occurred_at_desc"),
+		},
+	})
+	return err
+}
+
+func (r *UserActivityRepository) Append(ctx context.Context, activity entities.UserActivity) error {
+	if activity.CreatedAt.IsZero() {
+		activity.CreatedAt = time.Now().UTC()
+	}
+
+	_, err := r.getCollection().InsertOne(ctx, activity)
+	if mongo.IsDuplicateKeyError(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to insert user activity: %w", err)
+	}
+
+	return nil
+}
+
+func (r *UserActivityRepository) ListByUserID(
+	ctx context.Context,
+	userID string,
+	skip int64,
+	limit int64,
+) ([]entities.UserActivity, int64, error) {
+	filter := bson.M{"user_id": userID}
+
+	total, err := r.getCollection().CountDocuments(ctx, filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to count user activity: %w", err)
+	}
+
+	opts := options.Find().SetSkip(skip).SetLimit(limit).SetSort(bson.D{{Key: "occurred_at", Value: -1}})
+	cur, err := r.getCollection().Find(ctx, filter, opts)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to query user activity: %w", err)
+	}
+	defer cur.Close(ctx)
+
+	items := make([]entities.UserActivity, 0)
+	if err := cur.All(ctx, &items); err != nil {
+		return nil, 0, fmt.Errorf("failed to decode user activity: %w", err)
+	}
+
+	return items, total, nil
+}

--- a/user-service/routers/router.go
+++ b/user-service/routers/router.go
@@ -10,7 +10,12 @@ import (
 )
 
 // HandleRequests wires HTTP routes to user handlers.
-func HandleRequests(h *handlers.UserHandler, rth *handlers.RefreshTokenHandler, prh *handlers.PasswordRecoveryHandler) http.Handler {
+func HandleRequests(
+	h *handlers.UserHandler,
+	rth *handlers.RefreshTokenHandler,
+	prh *handlers.PasswordRecoveryHandler,
+	ah *handlers.UserActivityHandler,
+) http.Handler {
 	r := mux.NewRouter()
 	middlewares.HandleHealthz(r)
 
@@ -40,6 +45,7 @@ func HandleRequests(h *handlers.UserHandler, rth *handlers.RefreshTokenHandler, 
 	api.Handle("/change-password", middlewares.RequireAuthenticated(h.HandleChangePassword)).Methods("PATCH")
 	api.Handle("/profile", middlewares.RequireAuthenticated(h.HandleGetProfile)).Methods("GET")
 	api.Handle("/profile", middlewares.RequireAuthenticated(h.HandleUpdateProfile)).Methods("PATCH")
+	api.Handle("/activities", middlewares.RequireAuthenticated(ah.HandleGetMyActivities)).Methods("GET")
 
 	return r
 }

--- a/user-service/services/user_activity_service.go
+++ b/user-service/services/user_activity_service.go
@@ -1,0 +1,48 @@
+package services
+
+import (
+	"context"
+
+	commondtos "github.com/vanjmali/spotlite/common-lib/dtos"
+	"github.com/vanjmali/spotlite/common-lib/middlewares"
+	"github.com/vanjmali/spotlite/common-lib/pagination"
+	"github.com/vanjmali/spotlite/user-service/entities"
+)
+
+type UserActivityRepository interface {
+	Append(ctx context.Context, activity entities.UserActivity) error
+	ListByUserID(ctx context.Context, userID string, skip int64, limit int64) ([]entities.UserActivity, int64, error)
+}
+
+type UserActivityService struct {
+	r UserActivityRepository
+}
+
+func NewUserActivityService(r UserActivityRepository) *UserActivityService {
+	return &UserActivityService{r: r}
+}
+
+func (s *UserActivityService) Append(ctx context.Context, activity entities.UserActivity) error {
+	return s.r.Append(ctx, activity)
+}
+
+func (s *UserActivityService) ListMyActivities(
+	ctx context.Context,
+	page int,
+	size int,
+) (*commondtos.ItemCollectionResponse[entities.UserActivity], error) {
+	userID := middlewares.GetUserIdFromContext(ctx)
+	p := pagination.NewPagination(page, size)
+
+	items, total, err := s.r.ListByUserID(ctx, userID, p.Skip(), p.Limit())
+	if err != nil {
+		return nil, err
+	}
+
+	return &commondtos.ItemCollectionResponse[entities.UserActivity]{
+		Items: items,
+		Page:  p.Page,
+		Size:  p.Size,
+		Total: total,
+	}, nil
+}


### PR DESCRIPTION
Implement user activity storage within `user-service` and listen to events from other services to popullate the fields.

Connects and moves frontend from sidebar to pop up from header.

<img width="523" height="748" alt="image" src="https://github.com/user-attachments/assets/58c2490d-2b9f-4472-b057-885ac9ee79c1" />
