### PR TITLE
Dedupe recipient IDs before Redis in notification dedup filter

### DIFF
--- a/notification-service/services/notification_service.go
+++ b/notification-service/services/notification_service.go
@@ -122,7 +122,13 @@ func filterDuplicateNotifications(rc *redis.Client, eventID string, userIDs []st
 	pipe := rc.Pipeline()
 
 	cmds := make(map[string]*redis.BoolCmd)
+	seen := make(map[string]struct{}, len(userIDs))
 	for _, uid := range userIDs {
+		if _, ok := seen[uid]; ok {
+			continue
+		}
+		seen[uid] = struct{}{}
+
 		key := fmt.Sprintf("notif:%s:%s", eventID, uid)
 		cmds[uid] = pipe.SetNX(ctx, key, "1", 15*time.Minute)
 	}


### PR DESCRIPTION
Resolves notifications not being sent with multiple genres selected upon creation.