### PR TITLE
Implement deployment to Kubernetes Cluster

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,7 @@ SRV_USER_SMTP_HOST=mailhog
 SRV_USER_SMTP_PORT=1025
 SRV_USER_SMTP_USERNAME=not_important # not checked in mailhog during local development
 SRV_USER_SMTP_PASSWORD=not_important # not checked in mailhog during local development
+SRV_USER_SMTP_TLS_POLICY=none # options: "none", "require", "prefer"
 SRV_USER_MAIL_FROM_ADDRESS=mail@spotlite.com
 
 # JWT Secret key used for signing

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,7 @@ name: Publish Images to GHCR
 
 on:
   push:
-    # TODO: Change to main branch before merging
-    # branches: [develop]
+    branches: [develop]
 
 permissions:
   contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,9 +98,9 @@ jobs:
       - publish-go-services
       - publish-frontend
     env:
-      SPOTLITE_REMOTE_HOST: ${{ vars.SPOTLITE_REMOTE_HOST }}
-      SPOTLITE_REMOTE_PORT: ${{ vars.SPOTLITE_REMOTE_PORT }}
-      SPOTLITE_REMOTE_USER: ${{ vars.SPOTLITE_REMOTE_USER }}
+      SPOTLITE_REMOTE_HOST: ${{ secrets.SPOTLITE_REMOTE_HOST }}
+      SPOTLITE_REMOTE_PORT: ${{ secrets.SPOTLITE_REMOTE_PORT }}
+      SPOTLITE_REMOTE_USER: ${{ secrets.SPOTLITE_REMOTE_USER }}
       SPOTLITE_REMOTE_PRIVATE_KEY: ${{ secrets.SPOTLITE_REMOTE_PRIVATE_KEY }}
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,3 +91,50 @@ jobs:
             API_BASE_URL=/api
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
+
+  deploy-k8s:
+    runs-on: ubuntu-latest
+    needs:
+      - publish-go-services
+      - publish-frontend
+    env:
+      SPOTLITE_REMOTE_HOST: ${{ vars.SPOTLITE_REMOTE_HOST }}
+      SPOTLITE_REMOTE_PORT: ${{ vars.SPOTLITE_REMOTE_PORT }}
+      SPOTLITE_REMOTE_USER: ${{ vars.SPOTLITE_REMOTE_USER }}
+      SPOTLITE_REMOTE_PRIVATE_KEY: ${{ secrets.SPOTLITE_REMOTE_PRIVATE_KEY }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Start SSH agent
+        uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ env.SPOTLITE_REMOTE_PRIVATE_KEY }}
+
+      - name: Add remote host to known_hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan -p "${{ env.SPOTLITE_REMOTE_PORT }}" -H "${{ env.SPOTLITE_REMOTE_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Upload k8s manifests
+        run: |
+          tar -czf - k8s | ssh -p "${{ env.SPOTLITE_REMOTE_PORT }}" \
+            "${{ env.SPOTLITE_REMOTE_USER }}"@"${{ env.SPOTLITE_REMOTE_HOST }}" \
+            "mkdir -p /tmp/spotlite && tar -xzf - -C /tmp/spotlite"
+
+      - name: Apply manifests and restart workloads
+        run: |
+          ssh -p "${{ env.SPOTLITE_REMOTE_PORT }}" "${{ env.SPOTLITE_REMOTE_USER }}"@"${{ env.SPOTLITE_REMOTE_HOST }}" '
+            set -e
+            export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+            kubectl apply -k /tmp/spotlite/k8s
+            kubectl -n spotlite rollout restart deployment/user-service deployment/content-service deployment/notification-service deployment/subscription-service deployment/rating-service deployment/recommendation-service deployment/frontend
+            kubectl -n spotlite rollout status deployment/user-service --timeout=180s
+            kubectl -n spotlite rollout status deployment/content-service --timeout=180s
+            kubectl -n spotlite rollout status deployment/notification-service --timeout=180s
+            kubectl -n spotlite rollout status deployment/subscription-service --timeout=180s
+            kubectl -n spotlite rollout status deployment/rating-service --timeout=180s
+            kubectl -n spotlite rollout status deployment/recommendation-service --timeout=180s
+            kubectl -n spotlite rollout status deployment/frontend --timeout=180s
+            kubectl -n spotlite get pods
+          '

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -1,0 +1,93 @@
+name: Publish Images to GHCR
+
+on:
+  push:
+    # TODO: Change to main branch before merging
+    # branches: [develop]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-go-services:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: user-service
+            context: ./user-service
+            dockerfile: ./Dockerfile.microservice
+          - service: content-service
+            context: ./content-service
+            dockerfile: ./content-service/Dockerfile
+          - service: notification-service
+            context: ./notification-service
+            dockerfile: ./Dockerfile.microservice
+          - service: subscription-service
+            context: ./subscription-service
+            dockerfile: ./Dockerfile.microservice
+          - service: rating-service
+            context: ./rating-service
+            dockerfile: ./Dockerfile.microservice
+          - service: recommendation-service
+            context: ./recommendation-service
+            dockerfile: ./Dockerfile.microservice
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.service }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ghcr.io/vanjmali/spotlite:${{ matrix.service }}
+          build-contexts: |
+            common-lib=./common-lib
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+
+  publish-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          tags: ghcr.io/vanjmali/spotlite:frontend
+          build-args: |
+            API_BASE_URL=/api
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -13,5 +13,6 @@ RUN : "${API_BASE_URL:?API_BASE_URL build arg is required}" \
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
 COPY --from=build /app/dist/spotlite/browser /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,17 @@
+server {
+  listen 8080;
+  server_name _;
+
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+
+  location /assets/ {
+    try_files $uri =404;
+    access_log off;
+    expires 7d;
+  }
+}

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,67 @@
+# Spotlite Kubernetes
+
+This folder now uses a simple per-service layout.
+
+## Deploy command
+
+```bash
+kubectl apply -k k8s
+```
+
+## Files
+
+- `k8s/services/`: one file per app service deployment
+- `k8s/deps/`: databases, Redis, NATS, HDFS, Neo4j
+- `k8s/platform/`: ingress and routing
+- `k8s/secrets/spotlite-app-secrets.example.yaml`: app secret template
+
+## Required secrets before deploy
+
+Create namespace first:
+
+```bash
+kubectl apply -f k8s/namespace.yaml
+```
+
+1. App/env secret:
+
+```bash
+kubectl apply -n spotlite -f k8s/secrets/spotlite-app-secrets.example.yaml
+```
+
+2. Crypto secret (`spotlite-crypto`) with certs/keys:
+
+Required keys:
+
+- `rootCA.crt`
+- `nats.crt`, `nats.key`
+- `user-service.crt`, `user-service.key`
+- `content-service.crt`, `content-service.key`
+- `notification-service.crt`, `notification-service.key`
+- `subscription-service.crt`, `subscription-service.key`
+- `rating-service.crt`, `rating-service.key`
+- `recommendation-service.crt`, `recommendation-service.key`
+- `private.pem`, `public.pem`
+
+Example:
+
+```bash
+kubectl -n spotlite create secret generic spotlite-crypto \
+  --from-file=rootCA.crt=/path/to/rootCA.crt \
+  --from-file=nats.crt=/path/to/nats.crt \
+  --from-file=nats.key=/path/to/nats.key \
+  --from-file=user-service.crt=/path/to/user-service.crt \
+  --from-file=user-service.key=/path/to/user-service.key \
+  --from-file=content-service.crt=/path/to/content-service.crt \
+  --from-file=content-service.key=/path/to/content-service.key \
+  --from-file=notification-service.crt=/path/to/notification-service.crt \
+  --from-file=notification-service.key=/path/to/notification-service.key \
+  --from-file=subscription-service.crt=/path/to/subscription-service.crt \
+  --from-file=subscription-service.key=/path/to/subscription-service.key \
+  --from-file=rating-service.crt=/path/to/rating-service.crt \
+  --from-file=rating-service.key=/path/to/rating-service.key \
+  --from-file=recommendation-service.crt=/path/to/recommendation-service.crt \
+  --from-file=recommendation-service.key=/path/to/recommendation-service.key \
+  --from-file=private.pem=/path/to/private.pem \
+  --from-file=public.pem=/path/to/public.pem
+```

--- a/k8s/deps/content-hdfs.yaml
+++ b/k8s/deps/content-hdfs.yaml
@@ -1,0 +1,158 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: content-hdfs-namenode
+spec:
+  clusterIP: None
+  selector:
+    app: content-hdfs-namenode
+  ports:
+    - name: rpc
+      port: 8020
+      targetPort: 8020
+    - name: web
+      port: 9870
+      targetPort: 9870
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: content-hdfs-namenode
+spec:
+  serviceName: content-hdfs-namenode
+  replicas: 1
+  selector:
+    matchLabels:
+      app: content-hdfs-namenode
+  template:
+    metadata:
+      labels:
+        app: content-hdfs-namenode
+    spec:
+      containers:
+        - name: namenode
+          image: apache/hadoop:3.4
+          command: ["hdfs", "namenode"]
+          env:
+            - name: CLUSTER_NAME
+              value: spotlite-hdfs
+            - name: CORE-SITE.XML_fs.defaultFS
+              value: hdfs://content-hdfs-namenode:8020
+            - name: HDFS-SITE.XML_dfs.replication
+              value: "1"
+            - name: HDFS-SITE.XML_dfs.permissions.enabled
+              value: "false"
+            - name: HDFS-SITE.XML_dfs.namenode.name.dir
+              value: file:///data/dfs/name
+            - name: ENSURE_NAMENODE_DIR
+              value: /data/dfs/name
+          ports:
+            - containerPort: 8020
+              name: rpc
+            - containerPort: 9870
+              name: web
+          readinessProbe:
+            tcpSocket:
+              port: 8020
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            tcpSocket:
+              port: 8020
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: content-hdfs-datanode
+spec:
+  clusterIP: None
+  selector:
+    app: content-hdfs-datanode
+  ports:
+    - name: data
+      port: 9864
+      targetPort: 9864
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: content-hdfs-datanode
+spec:
+  serviceName: content-hdfs-datanode
+  replicas: 1
+  selector:
+    matchLabels:
+      app: content-hdfs-datanode
+  template:
+    metadata:
+      labels:
+        app: content-hdfs-datanode
+    spec:
+      initContainers:
+        - name: wait-for-namenode
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z content-hdfs-namenode 8020; do echo "waiting for content-hdfs-namenode"; sleep 3; done
+      containers:
+        - name: datanode
+          image: apache/hadoop:3.4
+          command: ["hdfs", "datanode"]
+          env:
+            - name: CLUSTER_NAME
+              value: spotlite-hdfs
+            - name: CORE-SITE.XML_fs.defaultFS
+              value: hdfs://content-hdfs-namenode:8020
+            - name: HDFS-SITE.XML_dfs.replication
+              value: "1"
+            - name: HDFS-SITE.XML_dfs.permissions.enabled
+              value: "false"
+            - name: HDFS-SITE.XML_dfs.datanode.data.dir
+              value: file:///data/dfs/data
+          ports:
+            - containerPort: 9864
+              name: data
+          readinessProbe:
+            tcpSocket:
+              port: 9864
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            tcpSocket:
+              port: 9864
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi

--- a/k8s/deps/content-hdfs.yaml
+++ b/k8s/deps/content-hdfs.yaml
@@ -1,9 +1,64 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: content-hdfs-config
+data:
+  core-site.xml: |
+    <?xml version="1.0"?>
+    <configuration>
+      <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://content-hdfs-namenode-0.content-hdfs-namenode.spotlite.svc.cluster.local:8020</value>
+      </property>
+    </configuration>
+  hdfs-site.xml: |
+    <?xml version="1.0"?>
+    <configuration>
+      <property>
+        <name>dfs.namenode.rpc-address</name>
+        <value>content-hdfs-namenode-0.content-hdfs-namenode.spotlite.svc.cluster.local:8020</value>
+      </property>
+      <property>
+        <name>dfs.namenode.rpc-bind-host</name>
+        <value>0.0.0.0</value>
+      </property>
+      <property>
+        <name>dfs.namenode.http-address</name>
+        <value>0.0.0.0:9870</value>
+      </property>
+      <property>
+        <name>dfs.namenode.http-bind-host</name>
+        <value>0.0.0.0</value>
+      </property>
+      <property>
+        <name>dfs.replication</name>
+        <value>1</value>
+      </property>
+      <property>
+        <name>dfs.permissions.enabled</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>dfs.namenode.datanode.registration.ip-hostname-check</name>
+        <value>false</value>
+      </property>
+      <property>
+        <name>dfs.namenode.name.dir</name>
+        <value>file:///data/dfs/name</value>
+      </property>
+      <property>
+        <name>dfs.datanode.data.dir</name>
+        <value>file:///data/dfs/data</value>
+      </property>
+    </configuration>
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: content-hdfs-namenode
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     app: content-hdfs-namenode
   ports:
@@ -32,20 +87,19 @@ spec:
       containers:
         - name: namenode
           image: apache/hadoop:3.4
-          command: ["hdfs", "namenode"]
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              mkdir -p /data/dfs/name
+              if [ ! -d /data/dfs/name/current ]; then
+                hdfs namenode -format -nonInteractive
+              fi
+              exec hdfs namenode
           env:
-            - name: CLUSTER_NAME
-              value: spotlite-hdfs
-            - name: CORE-SITE.XML_fs.defaultFS
-              value: hdfs://content-hdfs-namenode:8020
-            - name: HDFS-SITE.XML_dfs.replication
-              value: "1"
-            - name: HDFS-SITE.XML_dfs.permissions.enabled
-              value: "false"
-            - name: HDFS-SITE.XML_dfs.namenode.name.dir
-              value: file:///data/dfs/name
-            - name: ENSURE_NAMENODE_DIR
-              value: /data/dfs/name
+            - name: HADOOP_CONF_DIR
+              value: /etc/hadoop-conf
           ports:
             - containerPort: 8020
               name: rpc
@@ -68,6 +122,18 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            - name: config
+              mountPath: /etc/hadoop-conf/core-site.xml
+              subPath: core-site.xml
+              readOnly: true
+            - name: config
+              mountPath: /etc/hadoop-conf/hdfs-site.xml
+              subPath: hdfs-site.xml
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: content-hdfs-config
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -116,18 +182,16 @@ spec:
       containers:
         - name: datanode
           image: apache/hadoop:3.4
-          command: ["hdfs", "datanode"]
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              mkdir -p /data/dfs/data
+              exec hdfs datanode
           env:
-            - name: CLUSTER_NAME
-              value: spotlite-hdfs
-            - name: CORE-SITE.XML_fs.defaultFS
-              value: hdfs://content-hdfs-namenode:8020
-            - name: HDFS-SITE.XML_dfs.replication
-              value: "1"
-            - name: HDFS-SITE.XML_dfs.permissions.enabled
-              value: "false"
-            - name: HDFS-SITE.XML_dfs.datanode.data.dir
-              value: file:///data/dfs/data
+            - name: HADOOP_CONF_DIR
+              value: /etc/hadoop-conf
           ports:
             - containerPort: 9864
               name: data
@@ -148,6 +212,18 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            - name: config
+              mountPath: /etc/hadoop-conf/core-site.xml
+              subPath: core-site.xml
+              readOnly: true
+            - name: config
+              mountPath: /etc/hadoop-conf/hdfs-site.xml
+              subPath: hdfs-site.xml
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: content-hdfs-config
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/k8s/deps/content-mongodb.yaml
+++ b/k8s/deps/content-mongodb.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
         - name: mongodb
-          image: mongo:8.2
+          image: mongo:4.4
           ports:
             - containerPort: 27017
               name: mongodb
@@ -77,7 +77,7 @@ spec:
                 - sh
                 - -c
                 - >-
-                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  mongo --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
                   --password "$MONGO_INITDB_ROOT_PASSWORD"
                   --authenticationDatabase admin
                   --eval 'db.runCommand({ ping: 1 })'
@@ -91,7 +91,7 @@ spec:
                 - sh
                 - -c
                 - >-
-                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  mongo --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
                   --password "$MONGO_INITDB_ROOT_PASSWORD"
                   --authenticationDatabase admin
                   --eval 'db.runCommand({ ping: 1 })'

--- a/k8s/deps/content-mongodb.yaml
+++ b/k8s/deps/content-mongodb.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: content-mongodb-init
+data:
+  mongo-init.js: |
+    db = db.getSiblingDB(process.env.MONGO_INITDB_DATABASE);
+    db.createUser({
+      user: process.env.SRV_CONTENT_MONGO_USERNAME,
+      pwd: process.env.SRV_CONTENT_MONGO_PASSWORD,
+      roles: [{ role: "readWrite", db: db.getName() }]
+    });
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: content-mongodb
+spec:
+  clusterIP: None
+  selector:
+    app: content-mongodb
+  ports:
+    - name: mongodb
+      port: 27017
+      targetPort: 27017
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: content-mongodb
+spec:
+  serviceName: content-mongodb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: content-mongodb
+  template:
+    metadata:
+      labels:
+        app: content-mongodb
+    spec:
+      containers:
+        - name: mongodb
+          image: mongo:8.2
+          ports:
+            - containerPort: 27017
+              name: mongodb
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_CONTENT_MONGO_ROOT_USERNAME
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_CONTENT_MONGO_ROOT_PASSWORD
+            - name: MONGO_INITDB_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_CONTENT_MONGO_DATABASE
+            - name: SRV_CONTENT_MONGO_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_CONTENT_MONGO_USERNAME
+            - name: SRV_CONTENT_MONGO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_CONTENT_MONGO_PASSWORD
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - >-
+                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  --password "$MONGO_INITDB_ROOT_PASSWORD"
+                  --authenticationDatabase admin
+                  --eval 'db.runCommand({ ping: 1 })'
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - >-
+                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  --password "$MONGO_INITDB_ROOT_PASSWORD"
+                  --authenticationDatabase admin
+                  --eval 'db.runCommand({ ping: 1 })'
+            initialDelaySeconds: 40
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+            - name: mongo-init
+              mountPath: /docker-entrypoint-initdb.d/mongo-init.js
+              subPath: mongo-init.js
+              readOnly: true
+      volumes:
+        - name: mongo-init
+          configMap:
+            name: content-mongodb-init
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/deps/content-redis.yaml
+++ b/k8s/deps/content-redis.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: content-redis
+spec:
+  clusterIP: None
+  selector:
+    app: content-redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: content-redis
+spec:
+  serviceName: content-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: content-redis
+  template:
+    metadata:
+      labels:
+        app: content-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:8-alpine
+          command: ["redis-server", "--maxmemory", "512mb", "--maxmemory-policy", "allkeys-lfu"]
+          ports:
+            - containerPort: 6379
+              name: redis
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 2Gi

--- a/k8s/deps/nats.yaml
+++ b/k8s/deps/nats.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+spec:
+  clusterIP: None
+  selector:
+    app: nats
+  ports:
+    - name: client
+      port: 4222
+      targetPort: 4222
+    - name: monitor
+      port: 8222
+      targetPort: 8222
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: nats
+spec:
+  serviceName: nats
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nats
+  template:
+    metadata:
+      labels:
+        app: nats
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.12.4
+          args:
+            - -js
+            - -m
+            - "8222"
+            - --tls
+            - --tlscert=/certs/nats.crt
+            - --tlskey=/certs/nats.key
+          ports:
+            - containerPort: 4222
+              name: client
+            - containerPort: 8222
+              name: monitor
+          readinessProbe:
+            tcpSocket:
+              port: 4222
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 12
+          livenessProbe:
+            tcpSocket:
+              port: 4222
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 512Mi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: crypto
+              mountPath: /certs
+              readOnly: true
+      volumes:
+        - name: crypto
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: nats.crt
+                path: nats.crt
+              - key: nats.key
+                path: nats.key
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 2Gi

--- a/k8s/deps/notification-cassandra.yaml
+++ b/k8s/deps/notification-cassandra.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-cassandra
+spec:
+  clusterIP: None
+  selector:
+    app: notification-cassandra
+  ports:
+    - name: cql
+      port: 9042
+      targetPort: 9042
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: notification-cassandra
+spec:
+  serviceName: notification-cassandra
+  replicas: 1
+  selector:
+    matchLabels:
+      app: notification-cassandra
+  template:
+    metadata:
+      labels:
+        app: notification-cassandra
+    spec:
+      containers:
+        - name: cassandra
+          image: cassandra:5.0
+          env:
+            - name: CASSANDRA_CLUSTER_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: CASSANDRA_CLUSTER_NAME
+            - name: CASSANDRA_DC
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: CASSANDRA_DC
+            - name: CASSANDRA_RACK
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: CASSANDRA_RACK
+            - name: CASSANDRA_SEEDS
+              value: notification-cassandra
+            - name: MAX_HEAP_SIZE
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: CASSANDRA_MAX_HEAP
+            - name: HEAP_NEWSIZE
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: CASSANDRA_NEW_HEAP
+            - name: CASSANDRA_ENDPOINT_SNITCH
+              value: GossipingPropertyFileSnitch
+          ports:
+            - containerPort: 9042
+              name: cql
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "cqlsh -e 'SELECT release_version FROM system.local'"]
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            timeoutSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            tcpSocket:
+              port: 9042
+            initialDelaySeconds: 120
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 6
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/cassandra
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 8Gi

--- a/k8s/deps/notification-cassandra.yaml
+++ b/k8s/deps/notification-cassandra.yaml
@@ -4,6 +4,7 @@ metadata:
   name: notification-cassandra
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     app: notification-cassandra
   ports:
@@ -46,7 +47,7 @@ spec:
                   name: spotlite-app-secrets
                   key: CASSANDRA_RACK
             - name: CASSANDRA_SEEDS
-              value: notification-cassandra
+              value: notification-cassandra-0.notification-cassandra.spotlite.svc.cluster.local
             - name: MAX_HEAP_SIZE
               valueFrom:
                 secretKeyRef:

--- a/k8s/deps/notification-redis.yaml
+++ b/k8s/deps/notification-redis.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-redis
+spec:
+  clusterIP: None
+  selector:
+    app: notification-redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: notification-redis
+spec:
+  serviceName: notification-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: notification-redis
+  template:
+    metadata:
+      labels:
+        app: notification-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:8-alpine
+          command: ["redis-server", "--appendonly", "yes"]
+          ports:
+            - containerPort: 6379
+              name: redis
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 2Gi

--- a/k8s/deps/rating-mongodb.yaml
+++ b/k8s/deps/rating-mongodb.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rating-mongodb-init
+data:
+  mongo-init.js: |
+    db = db.getSiblingDB(process.env.MONGO_INITDB_DATABASE);
+    db.createUser({
+      user: process.env.SRV_RATING_MONGO_USERNAME,
+      pwd: process.env.SRV_RATING_MONGO_PASSWORD,
+      roles: [{ role: "readWrite", db: db.getName() }]
+    });
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rating-mongodb
+spec:
+  clusterIP: None
+  selector:
+    app: rating-mongodb
+  ports:
+    - name: mongodb
+      port: 27017
+      targetPort: 27017
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: rating-mongodb
+spec:
+  serviceName: rating-mongodb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rating-mongodb
+  template:
+    metadata:
+      labels:
+        app: rating-mongodb
+    spec:
+      containers:
+        - name: mongodb
+          image: mongo:8.2
+          ports:
+            - containerPort: 27017
+              name: mongodb
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_RATING_MONGO_ROOT_USERNAME
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_RATING_MONGO_ROOT_PASSWORD
+            - name: MONGO_INITDB_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_RATING_MONGO_DATABASE
+            - name: SRV_RATING_MONGO_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_RATING_MONGO_USERNAME
+            - name: SRV_RATING_MONGO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_RATING_MONGO_PASSWORD
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - >-
+                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  --password "$MONGO_INITDB_ROOT_PASSWORD"
+                  --authenticationDatabase admin
+                  --eval 'db.runCommand({ ping: 1 })'
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - >-
+                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  --password "$MONGO_INITDB_ROOT_PASSWORD"
+                  --authenticationDatabase admin
+                  --eval 'db.runCommand({ ping: 1 })'
+            initialDelaySeconds: 40
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+            - name: mongo-init
+              mountPath: /docker-entrypoint-initdb.d/mongo-init.js
+              subPath: mongo-init.js
+              readOnly: true
+      volumes:
+        - name: mongo-init
+          configMap:
+            name: rating-mongodb-init
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/deps/rating-mongodb.yaml
+++ b/k8s/deps/rating-mongodb.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
         - name: mongodb
-          image: mongo:8.2
+          image: mongo:4.4
           ports:
             - containerPort: 27017
               name: mongodb
@@ -77,7 +77,7 @@ spec:
                 - sh
                 - -c
                 - >-
-                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  mongo --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
                   --password "$MONGO_INITDB_ROOT_PASSWORD"
                   --authenticationDatabase admin
                   --eval 'db.runCommand({ ping: 1 })'
@@ -91,7 +91,7 @@ spec:
                 - sh
                 - -c
                 - >-
-                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  mongo --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
                   --password "$MONGO_INITDB_ROOT_PASSWORD"
                   --authenticationDatabase admin
                   --eval 'db.runCommand({ ping: 1 })'

--- a/k8s/deps/recommendation-neo4j.yaml
+++ b/k8s/deps/recommendation-neo4j.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: recommendation-neo4j
+spec:
+  selector:
+    app: recommendation-neo4j
+  ports:
+    - name: browser
+      port: 7474
+      targetPort: 7474
+    - name: bolt
+      port: 7687
+      targetPort: 7687
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: recommendation-neo4j
+spec:
+  serviceName: recommendation-neo4j
+  replicas: 1
+  selector:
+    matchLabels:
+      app: recommendation-neo4j
+  template:
+    metadata:
+      labels:
+        app: recommendation-neo4j
+    spec:
+      containers:
+        - name: neo4j
+          image: neo4j:5.18
+          env:
+            - name: NEO4J_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: NEO4J_AUTH
+            - name: NEO4J_dbms_security_procedures_unrestricted
+              value: apoc.*
+          ports:
+            - containerPort: 7474
+              name: browser
+            - containerPort: 7687
+              name: bolt
+          readinessProbe:
+            tcpSocket:
+              port: 7687
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            tcpSocket:
+              port: 7687
+            initialDelaySeconds: 40
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/deps/subscription-mongodb.yaml
+++ b/k8s/deps/subscription-mongodb.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
         - name: mongodb
-          image: mongo:8.2
+          image: mongo:4.4
           ports:
             - containerPort: 27017
               name: mongodb
@@ -77,7 +77,7 @@ spec:
                 - sh
                 - -c
                 - >-
-                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  mongo --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
                   --password "$MONGO_INITDB_ROOT_PASSWORD"
                   --authenticationDatabase admin
                   --eval 'db.runCommand({ ping: 1 })'
@@ -91,7 +91,7 @@ spec:
                 - sh
                 - -c
                 - >-
-                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  mongo --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
                   --password "$MONGO_INITDB_ROOT_PASSWORD"
                   --authenticationDatabase admin
                   --eval 'db.runCommand({ ping: 1 })'

--- a/k8s/deps/subscription-mongodb.yaml
+++ b/k8s/deps/subscription-mongodb.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: subscription-mongodb-init
+data:
+  mongo-init.js: |
+    db = db.getSiblingDB(process.env.MONGO_INITDB_DATABASE);
+    db.createUser({
+      user: process.env.SRV_SUB_MONGO_USERNAME,
+      pwd: process.env.SRV_SUB_MONGO_PASSWORD,
+      roles: [{ role: "readWrite", db: db.getName() }]
+    });
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: subscription-mongodb
+spec:
+  clusterIP: None
+  selector:
+    app: subscription-mongodb
+  ports:
+    - name: mongodb
+      port: 27017
+      targetPort: 27017
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: subscription-mongodb
+spec:
+  serviceName: subscription-mongodb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: subscription-mongodb
+  template:
+    metadata:
+      labels:
+        app: subscription-mongodb
+    spec:
+      containers:
+        - name: mongodb
+          image: mongo:8.2
+          ports:
+            - containerPort: 27017
+              name: mongodb
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_SUB_MONGO_ROOT_USERNAME
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_SUB_MONGO_ROOT_PASSWORD
+            - name: MONGO_INITDB_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_SUB_MONGO_DATABASE
+            - name: SRV_SUB_MONGO_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_SUB_MONGO_USERNAME
+            - name: SRV_SUB_MONGO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_SUB_MONGO_PASSWORD
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - >-
+                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  --password "$MONGO_INITDB_ROOT_PASSWORD"
+                  --authenticationDatabase admin
+                  --eval 'db.runCommand({ ping: 1 })'
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - >-
+                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  --password "$MONGO_INITDB_ROOT_PASSWORD"
+                  --authenticationDatabase admin
+                  --eval 'db.runCommand({ ping: 1 })'
+            initialDelaySeconds: 40
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+            - name: mongo-init
+              mountPath: /docker-entrypoint-initdb.d/mongo-init.js
+              subPath: mongo-init.js
+              readOnly: true
+      volumes:
+        - name: mongo-init
+          configMap:
+            name: subscription-mongodb-init
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/deps/user-mongodb.yaml
+++ b/k8s/deps/user-mongodb.yaml
@@ -1,0 +1,120 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-mongodb-init
+data:
+  mongo-init.js: |
+    db = db.getSiblingDB(process.env.MONGO_INITDB_DATABASE);
+    db.createUser({
+      user: process.env.SRV_USER_MONGO_USERNAME,
+      pwd: process.env.SRV_USER_MONGO_PASSWORD,
+      roles: [{ role: "readWrite", db: db.getName() }]
+    });
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-mongodb
+spec:
+  clusterIP: None
+  selector:
+    app: user-mongodb
+  ports:
+    - name: mongodb
+      port: 27017
+      targetPort: 27017
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: user-mongodb
+spec:
+  serviceName: user-mongodb
+  replicas: 1
+  selector:
+    matchLabels:
+      app: user-mongodb
+  template:
+    metadata:
+      labels:
+        app: user-mongodb
+    spec:
+      containers:
+        - name: mongodb
+          image: mongo:8.2
+          ports:
+            - containerPort: 27017
+              name: mongodb
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_USER_MONGO_ROOT_USERNAME
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_USER_MONGO_ROOT_PASSWORD
+            - name: MONGO_INITDB_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_USER_MONGO_DATABASE
+            - name: SRV_USER_MONGO_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_USER_MONGO_USERNAME
+            - name: SRV_USER_MONGO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_USER_MONGO_PASSWORD
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - >-
+                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  --password "$MONGO_INITDB_ROOT_PASSWORD"
+                  --authenticationDatabase admin
+                  --eval 'db.runCommand({ ping: 1 })'
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - >-
+                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  --password "$MONGO_INITDB_ROOT_PASSWORD"
+                  --authenticationDatabase admin
+                  --eval 'db.runCommand({ ping: 1 })'
+            initialDelaySeconds: 40
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+            - name: mongo-init
+              mountPath: /docker-entrypoint-initdb.d/mongo-init.js
+              subPath: mongo-init.js
+              readOnly: true
+      volumes:
+        - name: mongo-init
+          configMap:
+            name: user-mongodb-init
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi

--- a/k8s/deps/user-mongodb.yaml
+++ b/k8s/deps/user-mongodb.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
         - name: mongodb
-          image: mongo:8.2
+          image: mongo:4.4
           ports:
             - containerPort: 27017
               name: mongodb
@@ -77,7 +77,7 @@ spec:
                 - sh
                 - -c
                 - >-
-                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  mongo --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
                   --password "$MONGO_INITDB_ROOT_PASSWORD"
                   --authenticationDatabase admin
                   --eval 'db.runCommand({ ping: 1 })'
@@ -91,7 +91,7 @@ spec:
                 - sh
                 - -c
                 - >-
-                  mongosh --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
+                  mongo --quiet --username "$MONGO_INITDB_ROOT_USERNAME"
                   --password "$MONGO_INITDB_ROOT_PASSWORD"
                   --authenticationDatabase admin
                   --eval 'db.runCommand({ ping: 1 })'

--- a/k8s/deps/user-redis.yaml
+++ b/k8s/deps/user-redis.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-redis
+spec:
+  clusterIP: None
+  selector:
+    app: user-redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: user-redis
+spec:
+  serviceName: user-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: user-redis
+  template:
+    metadata:
+      labels:
+        app: user-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:8-alpine
+          command: ["redis-server", "--appendonly", "yes"]
+          ports:
+            - containerPort: 6379
+              name: redis
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 3
+          volumeMounts:
+            - name: data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 2Gi

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: spotlite
+resources:
+  - namespace.yaml
+  - platform/ingress-traefik.yaml
+  - deps/nats.yaml
+  - deps/user-mongodb.yaml
+  - deps/user-redis.yaml
+  - deps/content-mongodb.yaml
+  - deps/content-redis.yaml
+  - deps/content-hdfs.yaml
+  - deps/notification-cassandra.yaml
+  - deps/notification-redis.yaml
+  - deps/subscription-mongodb.yaml
+  - deps/rating-mongodb.yaml
+  - deps/recommendation-neo4j.yaml
+  - services/user-service.yaml
+  - services/content-service.yaml
+  - services/notification-service.yaml
+  - services/subscription-service.yaml
+  - services/rating-service.yaml
+  - services/recommendation-service.yaml
+  - services/frontend.yaml

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spotlite

--- a/k8s/platform/ingress-traefik.yaml
+++ b/k8s/platform/ingress-traefik.yaml
@@ -66,12 +66,39 @@ spec:
     forceSlash: false
 ---
 apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: redirect-to-https
+spec:
+  redirectScheme:
+    scheme: https
+    permanent: true
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: spotlite-http-redirect
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: PathPrefix(`/`)
+      middlewares:
+        - name: redirect-to-https
+      services:
+        - name: frontend
+          port: 8080
+---
+apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: spotlite
 spec:
   entryPoints:
-    - web
+    - websecure
+  tls:
+    secretName: spotlite-app-tls
   routes:
     - kind: Rule
       match: PathPrefix(`/api/users`)

--- a/k8s/platform/ingress-traefik.yaml
+++ b/k8s/platform/ingress-traefik.yaml
@@ -1,0 +1,141 @@
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: backend-https-transport
+spec:
+  insecureSkipVerify: true
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: user-service-strip-prefix
+spec:
+  stripPrefix:
+    prefixes:
+      - /api/users
+    forceSlash: false
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: content-service-strip-prefix
+spec:
+  stripPrefix:
+    prefixes:
+      - /api/content
+    forceSlash: false
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: notification-service-strip-prefix
+spec:
+  stripPrefix:
+    prefixes:
+      - /api/notifications
+    forceSlash: false
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: subscription-service-strip-prefix
+spec:
+  stripPrefix:
+    prefixes:
+      - /api/subscriptions
+    forceSlash: false
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: rating-service-strip-prefix
+spec:
+  stripPrefix:
+    prefixes:
+      - /api/ratings
+    forceSlash: false
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: recommendation-service-strip-prefix
+spec:
+  stripPrefix:
+    prefixes:
+      - /api/recommendations
+    forceSlash: false
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: spotlite
+spec:
+  entryPoints:
+    - web
+  routes:
+    - kind: Rule
+      match: PathPrefix(`/api/users`)
+      priority: 100
+      middlewares:
+        - name: user-service-strip-prefix
+      services:
+        - name: user-service
+          port: 3000
+          scheme: https
+          serversTransport: backend-https-transport
+    - kind: Rule
+      match: PathPrefix(`/api/content`)
+      priority: 99
+      middlewares:
+        - name: content-service-strip-prefix
+      services:
+        - name: content-service
+          port: 3000
+          scheme: https
+          serversTransport: backend-https-transport
+    - kind: Rule
+      match: PathPrefix(`/api/notifications`)
+      priority: 98
+      middlewares:
+        - name: notification-service-strip-prefix
+      services:
+        - name: notification-service
+          port: 3000
+          scheme: https
+          serversTransport: backend-https-transport
+    - kind: Rule
+      match: PathPrefix(`/api/subscriptions`)
+      priority: 97
+      middlewares:
+        - name: subscription-service-strip-prefix
+      services:
+        - name: subscription-service
+          port: 3000
+          scheme: https
+          serversTransport: backend-https-transport
+    - kind: Rule
+      match: PathPrefix(`/api/ratings`)
+      priority: 96
+      middlewares:
+        - name: rating-service-strip-prefix
+      services:
+        - name: rating-service
+          port: 3000
+          scheme: https
+          serversTransport: backend-https-transport
+    - kind: Rule
+      match: PathPrefix(`/api/recommendations`)
+      priority: 95
+      middlewares:
+        - name: recommendation-service-strip-prefix
+      services:
+        - name: recommendation-service
+          port: 3000
+          scheme: https
+          serversTransport: backend-https-transport
+    - kind: Rule
+      match: PathPrefix(`/`)
+      priority: 1
+      services:
+        - name: frontend
+          port: 8080

--- a/k8s/secrets/spotlite-app-secrets.example.yaml
+++ b/k8s/secrets/spotlite-app-secrets.example.yaml
@@ -15,12 +15,13 @@ stringData:
   SMTP_PORT: "1025"
   SMTP_USER: test-user
   SMTP_PASS: test-pass
+  SMTP_TLS_POLICY: none
   MAIL_FROM: noreply@example.com
 
-  SRV_USER_VERIFY_URL: https://example.com/verify
-  SRV_USER_PASSWORD_RESET_URL: https://example.com/reset-password
+  SRV_USER_VERIFY_URL: https://example.com/register/verify
+  SRV_USER_PASSWORD_RESET_URL: https://example.com/login/reset
   APP_LOGIN_OTP_TTL_MINUTES: "10"
-  APP_REFRESH_COOKIE_NAME: refresh_token
+  APP_REFRESH_COOKIE_NAME: auth
   APP_REFRESH_COOKIE_DOMAIN: example.com
   APP_REFRESH_COOKIE_SECURE: "true"
   APP_REFRESH_COOKIE_SAMESITE: lax

--- a/k8s/secrets/spotlite-app-secrets.example.yaml
+++ b/k8s/secrets/spotlite-app-secrets.example.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: spotlite-app-secrets
+type: Opaque
+stringData:
+  # User service + Mongo
+  SRV_USER_MONGO_ROOT_USERNAME: root
+  SRV_USER_MONGO_ROOT_PASSWORD: change-me
+  SRV_USER_MONGO_DATABASE: user-service
+  SRV_USER_MONGO_USERNAME: user-service
+  SRV_USER_MONGO_PASSWORD: change-me
+
+  SMTP_HOST: mailhog
+  SMTP_PORT: "1025"
+  SMTP_USER: test-user
+  SMTP_PASS: test-pass
+  MAIL_FROM: noreply@example.com
+
+  SRV_USER_VERIFY_URL: https://example.com/verify
+  SRV_USER_PASSWORD_RESET_URL: https://example.com/reset-password
+  APP_LOGIN_OTP_TTL_MINUTES: "10"
+  APP_REFRESH_COOKIE_NAME: refresh_token
+  APP_REFRESH_COOKIE_DOMAIN: example.com
+  APP_REFRESH_COOKIE_SECURE: "true"
+  APP_REFRESH_COOKIE_SAMESITE: lax
+
+  # Content service + Mongo + HDFS
+  SRV_CONTENT_MONGO_ROOT_USERNAME: root
+  SRV_CONTENT_MONGO_ROOT_PASSWORD: change-me
+  SRV_CONTENT_MONGO_DATABASE: content-service
+  SRV_CONTENT_MONGO_USERNAME: content-service
+  SRV_CONTENT_MONGO_PASSWORD: change-me
+  SRV_CONTENT_HDFS_AUDIO_BASE: /spotlite/audio
+  SRV_CONTENT_HDFS_USER: content-service
+  SRV_CONTENT_HDFS_DATA_TRANSFER_PROTECTION: none
+  SONG_RATING_CACHE_TTL_SECONDS: "30"
+
+  # Subscription service + Mongo
+  SRV_SUB_MONGO_ROOT_USERNAME: root
+  SRV_SUB_MONGO_ROOT_PASSWORD: change-me
+  SRV_SUB_MONGO_DATABASE: subscription-service
+  SRV_SUB_MONGO_USERNAME: subscription-service
+  SRV_SUB_MONGO_PASSWORD: change-me
+
+  # Rating service + Mongo
+  SRV_RATING_MONGO_ROOT_USERNAME: root
+  SRV_RATING_MONGO_ROOT_PASSWORD: change-me
+  SRV_RATING_MONGO_DATABASE: rating-service
+  SRV_RATING_MONGO_USERNAME: rating-service
+  SRV_RATING_MONGO_PASSWORD: change-me
+
+  # Notification service + Cassandra
+  CASSANDRA_CLUSTER_NAME: spotlite
+  CASSANDRA_DC: datacenter1
+  CASSANDRA_RACK: rack1
+  CASSANDRA_MAX_HEAP: 512M
+  CASSANDRA_NEW_HEAP: 128M
+  CASSANDRA_KEYSPACE: notification_service
+
+  # Recommendation service + Neo4j
+  NEO4J_USER: neo4j
+  NEO4J_PASSWORD: change-me-neo4j
+  NEO4J_AUTH: neo4j/change-me-neo4j

--- a/k8s/services/content-service.yaml
+++ b/k8s/services/content-service.yaml
@@ -1,0 +1,171 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: content-service
+spec:
+  selector:
+    app: content-service
+  ports:
+    - name: https
+      port: 3000
+      targetPort: 3000
+    - name: grpc
+      port: 50051
+      targetPort: 50051
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: content-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: content-service
+  template:
+    metadata:
+      labels:
+        app: content-service
+    spec:
+      initContainers:
+        - name: wait-deps
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z content-mongodb 27017; do echo "waiting for content-mongodb"; sleep 2; done
+              until nc -z content-redis 6379; do echo "waiting for content-redis"; sleep 2; done
+              until nc -z content-hdfs-namenode 8020; do echo "waiting for content-hdfs-namenode"; sleep 2; done
+              until nc -z nats 4222; do echo "waiting for nats"; sleep 2; done
+      containers:
+        - name: content-service
+          image: ghcr.io/vanjmali/spotlite:content-service
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              name: https
+            - containerPort: 50051
+              name: grpc
+          env:
+            - name: APP_PORT
+              value: "3000"
+            - name: REDIS_ADDR
+              value: content-redis:6379
+            - name: DB_HOST
+              value: content-mongodb
+            - name: DB_PORT
+              value: "27017"
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_CONTENT_MONGO_USERNAME
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_CONTENT_MONGO_PASSWORD
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_CONTENT_MONGO_DATABASE
+            - name: HDFS_URI
+              value: content-hdfs-namenode:8020
+            - name: HDFS_AUDIO_BASE
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_CONTENT_HDFS_AUDIO_BASE
+            - name: HDFS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_CONTENT_HDFS_USER
+            - name: HDFS_DATA_TRANSFER_PROTECTION
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_CONTENT_HDFS_DATA_TRANSFER_PROTECTION
+            - name: GRPC_PORT
+              value: "50051"
+            - name: RATING_GRPC_ADDRESS
+              value: rating-service:50051
+            - name: SONG_RATING_CACHE_TTL_SECONDS
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SONG_RATING_CACHE_TTL_SECONDS
+            - name: NATS_URL
+              value: tls://nats:4222
+            - name: ROOT_CERT_PATH
+              value: /certs/rootCA.crt
+            - name: CERT_PATH
+              value: /certs/content-service.crt
+            - name: KEY_PATH
+              value: /certs/content-service.key
+            - name: JWT_PRIVATE_KEY_PATH
+              value: /run/keys/private.pem
+            - name: JWT_PUBLIC_KEY_PATH
+              value: /run/keys/public.pem
+            - name: LOG_DIR
+              value: /app/logs
+            - name: LOG_ROTATE_MAX_SIZE_MB
+              value: "10"
+            - name: LOG_ROTATE_MAX_BACKUPS
+              value: "5"
+            - name: LOG_ROTATE_MAX_AGE_DAYS
+              value: "30"
+            - name: LOG_ROTATE_COMPRESS
+              value: "true"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
+          volumeMounts:
+            - name: crypto
+              mountPath: /certs
+              readOnly: true
+            - name: jwt-keys
+              mountPath: /run/keys
+              readOnly: true
+      volumes:
+        - name: crypto
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: rootCA.crt
+                path: rootCA.crt
+              - key: content-service.crt
+                path: content-service.crt
+              - key: content-service.key
+                path: content-service.key
+        - name: jwt-keys
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: private.pem
+                path: private.pem
+              - key: public.pem
+                path: public.pem

--- a/k8s/services/content-service.yaml
+++ b/k8s/services/content-service.yaml
@@ -110,7 +110,7 @@ spec:
             - name: JWT_PUBLIC_KEY_PATH
               value: /run/keys/public.pem
             - name: LOG_DIR
-              value: /app/logs
+              value: /tmp/logs
             - name: LOG_ROTATE_MAX_SIZE_MB
               value: "10"
             - name: LOG_ROTATE_MAX_BACKUPS

--- a/k8s/services/frontend.yaml
+++ b/k8s/services/frontend.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/vanjmali/spotlite:frontend
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+              name: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3

--- a/k8s/services/notification-service.yaml
+++ b/k8s/services/notification-service.yaml
@@ -1,0 +1,130 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-service
+spec:
+  selector:
+    app: notification-service
+  ports:
+    - name: https
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notification-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: notification-service
+  template:
+    metadata:
+      labels:
+        app: notification-service
+    spec:
+      initContainers:
+        - name: wait-deps
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z notification-cassandra 9042; do echo "waiting for notification-cassandra"; sleep 3; done
+              until nc -z notification-redis 6379; do echo "waiting for notification-redis"; sleep 2; done
+              until nc -z nats 4222; do echo "waiting for nats"; sleep 2; done
+      containers:
+        - name: notification-service
+          image: ghcr.io/vanjmali/spotlite:notification-service
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              name: https
+          env:
+            - name: APP_PORT
+              value: "3000"
+            - name: REDIS_ADDR
+              value: notification-redis:6379
+            - name: CASSANDRA_HOST
+              value: notification-cassandra
+            - name: CASSANDRA_PORT
+              value: "9042"
+            - name: CASSANDRA_DC
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: CASSANDRA_DC
+            - name: CASSANDRA_KEYSPACE
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: CASSANDRA_KEYSPACE
+            - name: NATS_URL
+              value: tls://nats:4222
+            - name: ROOT_CERT_PATH
+              value: /certs/rootCA.crt
+            - name: CERT_PATH
+              value: /certs/notification-service.crt
+            - name: KEY_PATH
+              value: /certs/notification-service.key
+            - name: JWT_PUBLIC_KEY_PATH
+              value: /run/keys/public.pem
+            - name: LOG_DIR
+              value: /app/logs
+            - name: LOG_ROTATE_MAX_SIZE_MB
+              value: "10"
+            - name: LOG_ROTATE_MAX_BACKUPS
+              value: "5"
+            - name: LOG_ROTATE_MAX_AGE_DAYS
+              value: "30"
+            - name: LOG_ROTATE_COMPRESS
+              value: "true"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
+          volumeMounts:
+            - name: crypto
+              mountPath: /certs
+              readOnly: true
+            - name: jwt-key
+              mountPath: /run/keys
+              readOnly: true
+      volumes:
+        - name: crypto
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: rootCA.crt
+                path: rootCA.crt
+              - key: notification-service.crt
+                path: notification-service.crt
+              - key: notification-service.key
+                path: notification-service.key
+        - name: jwt-key
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: public.pem
+                path: public.pem

--- a/k8s/services/notification-service.yaml
+++ b/k8s/services/notification-service.yaml
@@ -71,7 +71,7 @@ spec:
             - name: JWT_PUBLIC_KEY_PATH
               value: /run/keys/public.pem
             - name: LOG_DIR
-              value: /app/logs
+              value: /tmp/logs
             - name: LOG_ROTATE_MAX_SIZE_MB
               value: "10"
             - name: LOG_ROTATE_MAX_BACKUPS

--- a/k8s/services/rating-service.yaml
+++ b/k8s/services/rating-service.yaml
@@ -83,7 +83,7 @@ spec:
             - name: JWT_PUBLIC_KEY_PATH
               value: /run/keys/public.pem
             - name: LOG_DIR
-              value: /app/logs
+              value: /tmp/logs
             - name: LOG_ROTATE_MAX_SIZE_MB
               value: "10"
             - name: LOG_ROTATE_MAX_BACKUPS

--- a/k8s/services/rating-service.yaml
+++ b/k8s/services/rating-service.yaml
@@ -1,0 +1,142 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rating-service
+spec:
+  selector:
+    app: rating-service
+  ports:
+    - name: https
+      port: 3000
+      targetPort: 3000
+    - name: grpc
+      port: 50051
+      targetPort: 50051
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rating-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rating-service
+  template:
+    metadata:
+      labels:
+        app: rating-service
+    spec:
+      initContainers:
+        - name: wait-deps
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z rating-mongodb 27017; do echo "waiting for rating-mongodb"; sleep 2; done
+              until nc -z content-service 50051; do echo "waiting for content-service grpc"; sleep 2; done
+              until nc -z nats 4222; do echo "waiting for nats"; sleep 2; done
+      containers:
+        - name: rating-service
+          image: ghcr.io/vanjmali/spotlite:rating-service
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              name: https
+            - containerPort: 50051
+              name: grpc
+          env:
+            - name: APP_PORT
+              value: "3000"
+            - name: DB_HOST
+              value: rating-mongodb
+            - name: DB_PORT
+              value: "27017"
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_RATING_MONGO_USERNAME
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_RATING_MONGO_PASSWORD
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_RATING_MONGO_DATABASE
+            - name: CONTENT_GRPC_ADDRESS
+              value: content-service:50051
+            - name: GRPC_PORT
+              value: "50051"
+            - name: NATS_URL
+              value: tls://nats:4222
+            - name: ROOT_CERT_PATH
+              value: /certs/rootCA.crt
+            - name: CERT_PATH
+              value: /certs/rating-service.crt
+            - name: KEY_PATH
+              value: /certs/rating-service.key
+            - name: JWT_PUBLIC_KEY_PATH
+              value: /run/keys/public.pem
+            - name: LOG_DIR
+              value: /app/logs
+            - name: LOG_ROTATE_MAX_SIZE_MB
+              value: "10"
+            - name: LOG_ROTATE_MAX_BACKUPS
+              value: "5"
+            - name: LOG_ROTATE_MAX_AGE_DAYS
+              value: "30"
+            - name: LOG_ROTATE_COMPRESS
+              value: "true"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
+          volumeMounts:
+            - name: crypto
+              mountPath: /certs
+              readOnly: true
+            - name: jwt-key
+              mountPath: /run/keys
+              readOnly: true
+      volumes:
+        - name: crypto
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: rootCA.crt
+                path: rootCA.crt
+              - key: rating-service.crt
+                path: rating-service.crt
+              - key: rating-service.key
+                path: rating-service.key
+        - name: jwt-key
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: public.pem
+                path: public.pem

--- a/k8s/services/recommendation-service.yaml
+++ b/k8s/services/recommendation-service.yaml
@@ -1,0 +1,125 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: recommendation-service
+spec:
+  selector:
+    app: recommendation-service
+  ports:
+    - name: https
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: recommendation-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: recommendation-service
+  template:
+    metadata:
+      labels:
+        app: recommendation-service
+    spec:
+      initContainers:
+        - name: wait-deps
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z recommendation-neo4j 7687; do echo "waiting for recommendation-neo4j"; sleep 2; done
+              until nc -z nats 4222; do echo "waiting for nats"; sleep 2; done
+      containers:
+        - name: recommendation-service
+          image: ghcr.io/vanjmali/spotlite:recommendation-service
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              name: https
+          env:
+            - name: APP_PORT
+              value: "3000"
+            - name: NEO4J_URI
+              value: bolt://recommendation-neo4j:7687
+            - name: NEO4J_USER
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: NEO4J_USER
+            - name: NEO4J_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: NEO4J_PASSWORD
+            - name: NATS_URL
+              value: tls://nats:4222
+            - name: ROOT_CERT_PATH
+              value: /certs/rootCA.crt
+            - name: CERT_PATH
+              value: /certs/recommendation-service.crt
+            - name: KEY_PATH
+              value: /certs/recommendation-service.key
+            - name: JWT_PUBLIC_KEY_PATH
+              value: /run/keys/public.pem
+            - name: LOG_DIR
+              value: /app/logs
+            - name: LOG_ROTATE_MAX_SIZE_MB
+              value: "10"
+            - name: LOG_ROTATE_MAX_BACKUPS
+              value: "5"
+            - name: LOG_ROTATE_MAX_AGE_DAYS
+              value: "30"
+            - name: LOG_ROTATE_COMPRESS
+              value: "true"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
+          volumeMounts:
+            - name: crypto
+              mountPath: /certs
+              readOnly: true
+            - name: jwt-key
+              mountPath: /run/keys
+              readOnly: true
+      volumes:
+        - name: crypto
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: rootCA.crt
+                path: rootCA.crt
+              - key: recommendation-service.crt
+                path: recommendation-service.crt
+              - key: recommendation-service.key
+                path: recommendation-service.key
+        - name: jwt-key
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: public.pem
+                path: public.pem

--- a/k8s/services/recommendation-service.yaml
+++ b/k8s/services/recommendation-service.yaml
@@ -66,7 +66,7 @@ spec:
             - name: JWT_PUBLIC_KEY_PATH
               value: /run/keys/public.pem
             - name: LOG_DIR
-              value: /app/logs
+              value: /tmp/logs
             - name: LOG_ROTATE_MAX_SIZE_MB
               value: "10"
             - name: LOG_ROTATE_MAX_BACKUPS

--- a/k8s/services/subscription-service.yaml
+++ b/k8s/services/subscription-service.yaml
@@ -1,0 +1,135 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: subscription-service
+spec:
+  selector:
+    app: subscription-service
+  ports:
+    - name: https
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: subscription-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: subscription-service
+  template:
+    metadata:
+      labels:
+        app: subscription-service
+    spec:
+      initContainers:
+        - name: wait-deps
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z subscription-mongodb 27017; do echo "waiting for subscription-mongodb"; sleep 2; done
+              until nc -z content-service 50051; do echo "waiting for content-service grpc"; sleep 2; done
+              until nc -z nats 4222; do echo "waiting for nats"; sleep 2; done
+      containers:
+        - name: subscription-service
+          image: ghcr.io/vanjmali/spotlite:subscription-service
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              name: https
+          env:
+            - name: APP_PORT
+              value: "3000"
+            - name: DB_HOST
+              value: subscription-mongodb
+            - name: DB_PORT
+              value: "27017"
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_SUB_MONGO_USERNAME
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_SUB_MONGO_PASSWORD
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_SUB_MONGO_DATABASE
+            - name: CONTENT_GRPC_ADDRESS
+              value: content-service:50051
+            - name: NATS_URL
+              value: tls://nats:4222
+            - name: ROOT_CERT_PATH
+              value: /certs/rootCA.crt
+            - name: CERT_PATH
+              value: /certs/subscription-service.crt
+            - name: KEY_PATH
+              value: /certs/subscription-service.key
+            - name: JWT_PUBLIC_KEY_PATH
+              value: /run/keys/public.pem
+            - name: LOG_DIR
+              value: /app/logs
+            - name: LOG_ROTATE_MAX_SIZE_MB
+              value: "10"
+            - name: LOG_ROTATE_MAX_BACKUPS
+              value: "5"
+            - name: LOG_ROTATE_MAX_AGE_DAYS
+              value: "30"
+            - name: LOG_ROTATE_COMPRESS
+              value: "true"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
+          volumeMounts:
+            - name: crypto
+              mountPath: /certs
+              readOnly: true
+            - name: jwt-key
+              mountPath: /run/keys
+              readOnly: true
+      volumes:
+        - name: crypto
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: rootCA.crt
+                path: rootCA.crt
+              - key: subscription-service.crt
+                path: subscription-service.crt
+              - key: subscription-service.key
+                path: subscription-service.key
+        - name: jwt-key
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: public.pem
+                path: public.pem

--- a/k8s/services/subscription-service.yaml
+++ b/k8s/services/subscription-service.yaml
@@ -76,7 +76,7 @@ spec:
             - name: JWT_PUBLIC_KEY_PATH
               value: /run/keys/public.pem
             - name: LOG_DIR
-              value: /app/logs
+              value: /tmp/logs
             - name: LOG_ROTATE_MAX_SIZE_MB
               value: "10"
             - name: LOG_ROTATE_MAX_BACKUPS

--- a/k8s/services/user-service.yaml
+++ b/k8s/services/user-service.yaml
@@ -136,7 +136,7 @@ spec:
             - name: JWT_PUBLIC_KEY_PATH
               value: /run/keys/public.pem
             - name: LOG_DIR
-              value: /app/logs
+              value: /tmp/logs
             - name: LOG_ROTATE_MAX_SIZE_MB
               value: "10"
             - name: LOG_ROTATE_MAX_BACKUPS

--- a/k8s/services/user-service.yaml
+++ b/k8s/services/user-service.yaml
@@ -1,0 +1,197 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: user-service
+spec:
+  selector:
+    app: user-service
+  ports:
+    - name: https
+      port: 3000
+      targetPort: 3000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: user-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: user-service
+  template:
+    metadata:
+      labels:
+        app: user-service
+    spec:
+      initContainers:
+        - name: wait-deps
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z user-mongodb 27017; do echo "waiting for user-mongodb"; sleep 2; done
+              until nc -z user-redis 6379; do echo "waiting for user-redis"; sleep 2; done
+              until nc -z nats 4222; do echo "waiting for nats"; sleep 2; done
+      containers:
+        - name: user-service
+          image: ghcr.io/vanjmali/spotlite:user-service
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+              name: https
+          env:
+            - name: APP_PORT
+              value: "3000"
+            - name: REDIS_ADDR
+              value: user-redis:6379
+            - name: DB_HOST
+              value: user-mongodb
+            - name: DB_PORT
+              value: "27017"
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_USER_MONGO_USERNAME
+            - name: DB_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_USER_MONGO_PASSWORD
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_USER_MONGO_DATABASE
+            - name: SMTP_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SMTP_HOST
+            - name: SMTP_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SMTP_PORT
+            - name: SMTP_USER
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SMTP_USER
+            - name: SMTP_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SMTP_PASS
+            - name: MAIL_FROM
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: MAIL_FROM
+            - name: SRV_USER_VERIFY_URL
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_USER_VERIFY_URL
+            - name: SRV_USER_PASSWORD_RESET_URL
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SRV_USER_PASSWORD_RESET_URL
+            - name: APP_LOGIN_OTP_TTL_MINUTES
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: APP_LOGIN_OTP_TTL_MINUTES
+            - name: APP_REFRESH_COOKIE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: APP_REFRESH_COOKIE_NAME
+            - name: APP_REFRESH_COOKIE_DOMAIN
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: APP_REFRESH_COOKIE_DOMAIN
+            - name: APP_REFRESH_COOKIE_SECURE
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: APP_REFRESH_COOKIE_SECURE
+            - name: APP_REFRESH_COOKIE_SAMESITE
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: APP_REFRESH_COOKIE_SAMESITE
+            - name: ROOT_CERT_PATH
+              value: /certs/rootCA.crt
+            - name: CERT_PATH
+              value: /certs/user-service.crt
+            - name: KEY_PATH
+              value: /certs/user-service.key
+            - name: JWT_PRIVATE_KEY_PATH
+              value: /run/keys/private.pem
+            - name: JWT_PUBLIC_KEY_PATH
+              value: /run/keys/public.pem
+            - name: LOG_DIR
+              value: /app/logs
+            - name: LOG_ROTATE_MAX_SIZE_MB
+              value: "10"
+            - name: LOG_ROTATE_MAX_BACKUPS
+              value: "5"
+            - name: LOG_ROTATE_MAX_AGE_DAYS
+              value: "30"
+            - name: LOG_ROTATE_COMPRESS
+              value: "true"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+              scheme: HTTPS
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 60
+          volumeMounts:
+            - name: crypto
+              mountPath: /certs
+              readOnly: true
+            - name: jwt-keys
+              mountPath: /run/keys
+              readOnly: true
+      volumes:
+        - name: crypto
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: rootCA.crt
+                path: rootCA.crt
+              - key: user-service.crt
+                path: user-service.crt
+              - key: user-service.key
+                path: user-service.key
+        - name: jwt-keys
+          secret:
+            secretName: spotlite-crypto
+            items:
+              - key: private.pem
+                path: private.pem
+              - key: public.pem
+                path: public.pem

--- a/k8s/services/user-service.yaml
+++ b/k8s/services/user-service.yaml
@@ -85,6 +85,11 @@ spec:
                 secretKeyRef:
                   name: spotlite-app-secrets
                   key: SMTP_PASS
+            - name: SMTP_TLS_POLICY
+              valueFrom:
+                secretKeyRef:
+                  name: spotlite-app-secrets
+                  key: SMTP_TLS_POLICY
             - name: MAIL_FROM
               valueFrom:
                 secretKeyRef:

--- a/user-service/docker-compose.yml
+++ b/user-service/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       SMTP_PORT: ${SRV_USER_SMTP_PORT?}
       SMTP_USER: ${SRV_USER_SMTP_USERNAME?}
       SMTP_PASS: ${SRV_USER_SMTP_PASSWORD?}
+      SMTP_TLS_POLICY: ${SRV_USER_SMTP_TLS_POLICY?}
       MAIL_FROM: ${SRV_USER_MAIL_FROM_ADDRESS?}
       # JWT_PRIVATE_KEY_PATH: /run/keys/private.pem
       # JWT_PUBLIC_KEY_PATH: /run/keys/public.pem

--- a/user-service/infrastructure/mailing/client.go
+++ b/user-service/infrastructure/mailing/client.go
@@ -2,7 +2,9 @@ package mailing
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/vanjmali/spotlite/common-lib/logging"
 	"github.com/vanjmali/spotlite/common-lib/utils"
@@ -16,10 +18,14 @@ type MailClient struct {
 
 // InitClient builds the mail client.
 func InitClient(host string, port int, username string, password string) (*mail.Client, error) {
+	tlsPolicy, err := tlsPolicyFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
 	c, err := mail.NewClient(host,
 		mail.WithPort(port),
-		mail.WithTLSPolicy(mail.NoTLS), // Change Mandatory to NoTLS or TLSOptional
-		// TODO: configurable TLS
+		mail.WithTLSPolicy(tlsPolicy),
 		mail.WithSMTPAuth(mail.SMTPAuthPlainNoEnc),
 		mail.WithUsername(username),
 		mail.WithPassword(password))
@@ -30,6 +36,19 @@ func InitClient(host string, port int, username string, password string) (*mail.
 	logging.Infof(context.Background(), "mail client initialized successfully")
 
 	return c, nil
+}
+
+func tlsPolicyFromEnv() (mail.TLSPolicy, error) {
+	switch strings.ToLower(strings.TrimSpace(utils.GetEnv("SMTP_TLS_POLICY", "none"))) {
+	case "none":
+		return mail.NoTLS, nil
+	case "optional":
+		return mail.TLSOpportunistic, nil
+	case "mandatory":
+		return mail.TLSMandatory, nil
+	default:
+		return mail.NoTLS, fmt.Errorf("invalid SMTP_TLS_POLICY: use one of none|optional|mandatory")
+	}
 }
 
 // InitClientFromEnv builds the mail client using environment variables with sensible defaults.


### PR DESCRIPTION
Configures Github Actions to deploy to Kubernetes node configured to run for the demo.

This setup requires the Docker images to be published to a image registry, which we will use https://ghcr.io for. This is also done via GitHub Actions and does not pin versions. Image tag format is `ghcr.io/vanjmali/spotlite:<service>`.